### PR TITLE
Shipping manifest lifecycle: auto flower deduction, In Progress state, Chain of Custody-gated completion (0.16.0)

### DIFF
--- a/grace_addon/CHANGELOG.md
+++ b/grace_addon/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [0.16.0] - 2026-06-12
+### Added
+- **Manifest lifecycle**: Generating a shipping manifest now records it in the ledger as **In Progress**. It stays In Progress until the signed Chain of Custody (photo or PDF) is attached — a manifest cannot be completed without one (enforced server-side).
+- **Automatic flower deduction**: Flower shipped from us to an external company is deducted from the dried-flower ledger at the moment the manifest is generated (reason `Send external`, so monthly Agency reports and dashboard totals pick it up exactly like a manual entry). The generate page now explains this up front and shows the recorded stock for the selected genetics; generation is blocked if the manifest weight exceeds recorded stock.
+- **Complete Manifest page** (`complete_manifest.php`): lists every manifest awaiting completion (date, destination, what was shipped) and lets you pick one to complete by uploading the CoC or attaching one already uploaded on the Chain of Custody page. Replaces the "Amend / Complete Manifest — coming soon" card — manifests in transit are completed, not amended.
+- **Exchange summary page** (`manifest_summary.php`): source / destination / shipment details, inventory deduction, CoC download, and the manifest PDF for each exchange. Linked from the Chain of Custody page and the Complete Manifest page.
+- **Chain of Custody page**: now also shows all shipment exchanges with their status and CoC state. Manual standalone CoC uploads still work exactly as before.
+- **Dashboard**: "Manifests awaiting CoC" stat linking to the Complete Manifest page.
+- **Manifest PDFs are persisted** to `/data/uploads/manifests/` and re-downloadable from the summary page; the PDF now also carries the manifest number, genetics, and a note that it must be completed in GRACe.
+- **Database**: `ShippingManifests` gains `status`, party-name snapshots, genetics, quantity, destination, flower-transaction link, CoC link, and completion date. Existing installations are migrated in place automatically on first page load — no data loss, no manual steps.
+
+### Fixed
+- **Shipping manifest form**: sending and receiving parties no longer share form field names, so an external→external manifest records both companies correctly (previously the receiving company silently overwrote the sending one). The PDF no longer prints the literal text "us"/"external" as the preparing staff name.
+- **Shipping manifest processing**: generating a manifest is now a single POST/redirect flow — refreshing the result page can no longer re-run generation, and the stale session-replay code is gone.
+
 ## [0.15.1] - 2026-06-12
 ### Added
 - **Dashboard**: New landing page with at-a-glance stats (plants growing/drying, dried flower on hand, materials out this month), license renewal warnings, and quick actions. The portal now opens here instead of Plant Tracking.

--- a/grace_addon/DOCS.md
+++ b/grace_addon/DOCS.md
@@ -32,6 +32,19 @@ Then when you go to harvest them at the end of the season, go into the "Harvest/
 
 Next, once you've dried them, you can go into "Record dry weight change", select your genetics name, type in the weight you've harvested, choose "add" because we're adding weight to the running tally, and then choose "Harvested". If you'd received flower from another license holder (say, to see a sample of it before you got some genetics from them) you'd choose "Other".
 
+# Shipping & Chain of Custody
+
+When product physically leaves your site, generate a manifest under Tracking → "Generate Shipping Manifest". Pick the sending and receiving parties, the product type, the genetics and the quantity, and GRACe produces the manifest PDF for you to print and send with the shipment.
+
+Two things happen automatically at that moment:
+
+- If you're sending flower to an external company, the shipped weight is deducted from your dried-flower inventory straight away — you don't need to make a separate "Record dry weight change" entry, and it shows up in your monthly materials-out report like any other send.
+- The manifest is recorded as "In Progress". It stays that way while the product is in transit.
+
+Once the shipment has been received and you have the signed Chain of Custody back (a photo of the signed paperwork is fine, or a scanned PDF), go to Tracking → "Complete Manifest". You'll see every manifest still awaiting completion with its date, destination and what was shipped — choose the right one, attach the Chain of Custody, and complete it. GRACe will not let a manifest be closed off without a Chain of Custody attached.
+
+You can still upload standalone Chain of Custody paperwork on the Administration → "Chain of Custody Documents" page like before, and anything uploaded there can be attached to a manifest later from the Complete Manifest page. Each exchange also has a summary page (linked from both pages) showing the source, destination, shipment details, inventory deduction and the attached paperwork.
+
 # Reporting
 
 To take care of your monthly reporting obligations, you'll need to go to Reporting and then choose "This months materials out (Flower+Plants)". If you're doing it after the end of the month has rolled over (but within the first 7 days of the new month) you'll want to choose last months option.

--- a/grace_addon/config.yaml
+++ b/grace_addon/config.yaml
@@ -2,7 +2,7 @@ name: "GRACe Portal"
 description: "Growers Regulatory Assistance & Compliance engine"
 url: "https://www.chilldivision.co.nz"
 codenotary: josiah@chilldivision.co.nz
-version: "0.15.1"
+version: "0.16.0"
 slug: "grace_addon"
 panel_icon: mdi:cannabis
 init: false

--- a/grace_addon/files/general/www/public/chain_of_custody_documents.php
+++ b/grace_addon/files/general/www/public/chain_of_custody_documents.php
@@ -1,4 +1,10 @@
 <?php
+require_once 'init_db.php';
+require_once 'manifest_lib.php';
+
+$pdo = initializeDatabase();
+$manifests = fetchManifests($pdo);
+
 $pageTitle = 'GRACe - Chain of Custody Documents';
 $useJquery = true;
 require 'header.php';
@@ -17,7 +23,48 @@ require 'header.php';
                 <input type="hidden" name="category" value="coc">
                 <button type="submit">Upload</button>
             </form>
+            <p><small>Uploads here are stored as standalone documents. To close out a manifest in transit,
+            attach its CoC on the <a href="complete_manifest.php">Complete Manifest</a> page — documents
+            uploaded here can be selected there too.</small></p>
         </article>
+
+        <?php if ($manifests): ?>
+        <section>
+            <h2>Shipment Exchanges</h2>
+            <figure class="table-wrap">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Date</th>
+                            <th>Route</th>
+                            <th>Shipment</th>
+                            <th>Status</th>
+                            <th>CoC</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($manifests as $manifest): ?>
+                        <tr>
+                            <td><a href="manifest_summary.php?id=<?php echo (int) $manifest['id']; ?>"><?php echo (int) $manifest['id']; ?></a></td>
+                            <td><?php echo htmlspecialchars($manifest['shipment_date']); ?></td>
+                            <td><?php echo htmlspecialchars(manifestRouteLabel($manifest)); ?></td>
+                            <td><?php echo htmlspecialchars(manifestShipmentLabel($manifest)); ?></td>
+                            <td><?php echo manifestStatusBadge($manifest); ?></td>
+                            <td>
+                                <?php if ($manifest['coc_document_id']): ?>
+                                    <a href="download.php?category=coc&file=<?php echo urlencode($manifest['coc_unique_filename']); ?>" download>Attached</a>
+                                <?php else: ?>
+                                    <a href="complete_manifest.php?id=<?php echo (int) $manifest['id']; ?>">Pending</a>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </figure>
+        </section>
+        <?php endif; ?>
 
         <section>
             <h2>Existing Custody Documents</h2>

--- a/grace_addon/files/general/www/public/complete_manifest.php
+++ b/grace_addon/files/general/www/public/complete_manifest.php
@@ -1,0 +1,177 @@
+<?php
+require_once 'init_db.php';
+require_once 'manifest_lib.php';
+
+$pdo = initializeDatabase();
+
+$manifestId = (int) ($_GET['id'] ?? 0);
+$manifest = $manifestId ? fetchManifest($pdo, $manifestId) : null;
+
+if (!$manifest) {
+    // List mode: every manifest still awaiting its Chain of Custody
+    $pendingManifests = fetchManifests($pdo, 'In Progress');
+} else {
+    // Detail mode: CoC documents already uploaded manually that aren't tied
+    // to another manifest can be attached instead of uploading a new file
+    $stmt = $pdo->query("SELECT id, original_filename, upload_date FROM Documents
+                         WHERE category = 'coc'
+                           AND id NOT IN (SELECT coc_document_id FROM ShippingManifests WHERE coc_document_id IS NOT NULL)
+                         ORDER BY upload_date DESC");
+    $availableCocDocs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+$pageTitle = 'GRACe - Complete Manifest';
+require 'header.php';
+?>
+
+    <main class="container">
+        <hgroup class="page-header">
+            <h1>Complete Manifest</h1>
+            <p>Attach the signed Chain of Custody and close out manifests in transit.</p>
+        </hgroup>
+
+<?php if (!$manifest): ?>
+        <section>
+            <h2>Manifests Awaiting Completion</h2>
+            <?php if (!$pendingManifests): ?>
+                <article class="form-card"><p>No manifests are awaiting completion. <a href="generate_shipping_manifest.php">Generate a shipping manifest</a> to start one.</p></article>
+            <?php else: ?>
+            <figure class="table-wrap">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Date</th>
+                            <th>Destination</th>
+                            <th>Shipment</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($pendingManifests as $row): ?>
+                        <tr>
+                            <td><?php echo (int) $row['id']; ?></td>
+                            <td><?php echo htmlspecialchars($row['shipment_date']); ?></td>
+                            <td><?php echo htmlspecialchars($row['receiving_company_name']); ?></td>
+                            <td><?php echo htmlspecialchars(manifestShipmentLabel($row)); ?></td>
+                            <td>
+                                <a href="manifest_summary.php?id=<?php echo (int) $row['id']; ?>">Summary</a> ·
+                                <a href="complete_manifest.php?id=<?php echo (int) $row['id']; ?>">Complete</a>
+                            </td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </figure>
+            <?php endif; ?>
+        </section>
+<?php elseif ($manifest['status'] === 'Completed'): ?>
+        <article class="form-card">
+            <p>Manifest #<?php echo (int) $manifest['id']; ?> is already completed.</p>
+            <p><a href="manifest_summary.php?id=<?php echo (int) $manifest['id']; ?>">View the exchange summary</a></p>
+        </article>
+<?php else: ?>
+        <article class="form-card">
+            <h2>Manifest #<?php echo (int) $manifest['id']; ?> <?php echo manifestStatusBadge($manifest); ?></h2>
+            <figure class="table-wrap">
+                <table>
+                    <tbody>
+                        <tr><td><strong>Prepared</strong></td><td><?php echo htmlspecialchars($manifest['shipment_date']); ?></td></tr>
+                        <tr><td><strong>Route</strong></td><td><?php echo htmlspecialchars(manifestRouteLabel($manifest)); ?></td></tr>
+                        <tr><td><strong>Shipment</strong></td><td><?php echo htmlspecialchars(manifestShipmentLabel($manifest)); ?></td></tr>
+                    </tbody>
+                </table>
+            </figure>
+            <p><a href="manifest_summary.php?id=<?php echo (int) $manifest['id']; ?>">Full exchange summary</a></p>
+        </article>
+
+        <article class="form-card">
+            <h2>Attach Chain of Custody &amp; Complete</h2>
+            <p>A manifest cannot be completed without its signed Chain of Custody (photo or PDF).
+               Images over 1MB are compressed automatically.</p>
+            <form id="completeManifestForm">
+                <input type="hidden" name="manifest_id" value="<?php echo (int) $manifest['id']; ?>">
+
+                <label for="cocFile">Upload the signed Chain of Custody:</label>
+                <input type="file" id="cocFile" name="file" accept="image/*,.pdf">
+
+                <?php if (!empty($availableCocDocs)): ?>
+                <label for="existingDocId">…or attach one already uploaded on the Chain of Custody page:</label>
+                <select id="existingDocId" name="existing_document_id">
+                    <option value="">— Select an uploaded document —</option>
+                    <?php foreach ($availableCocDocs as $doc): ?>
+                    <option value="<?php echo (int) $doc['id']; ?>">
+                        <?php echo htmlspecialchars($doc['original_filename'] . ' (uploaded ' . $doc['upload_date'] . ')'); ?>
+                    </option>
+                    <?php endforeach; ?>
+                </select>
+                <?php endif; ?>
+
+                <button type="submit">Complete Manifest</button>
+            </form>
+        </article>
+
+        <script src="js/image-compress.js?v=<?php echo GRACE_ASSET_VERSION; ?>"></script>
+        <script>
+            document.getElementById('completeManifestForm').addEventListener('submit', async function (e) {
+                e.preventDefault();
+                const form = this;
+                const fileInput = document.getElementById('cocFile');
+                const existingSelect = document.getElementById('existingDocId');
+                const submitButton = form.querySelector('button[type="submit"]');
+
+                let file = fileInput.files[0] || null;
+                const existingDocId = existingSelect ? existingSelect.value : '';
+
+                if (!file && !existingDocId) {
+                    showToast('Attach a Chain of Custody photo or PDF before completing the manifest.', 'error');
+                    return;
+                }
+                if (file && existingDocId) {
+                    showToast('Choose either a new upload or an existing document, not both.', 'error');
+                    return;
+                }
+
+                const confirmed = await confirmAction({
+                    title: 'Complete manifest #<?php echo (int) $manifest['id']; ?>?',
+                    message: 'The Chain of Custody will be attached and the manifest closed. This cannot be undone.',
+                    confirmLabel: 'Complete Manifest'
+                });
+                if (!confirmed) return;
+
+                submitButton.disabled = true;
+                submitButton.textContent = 'Processing...';
+
+                try {
+                    if (file && file.type.match(/^image\//) && file.size > 1024 * 1024 && typeof compressImage === 'function') {
+                        submitButton.textContent = 'Compressing image...';
+                        file = await compressImage(file, 1024 * 1024);
+                    }
+
+                    const formData = new FormData();
+                    formData.append('manifest_id', form.querySelector('[name="manifest_id"]').value);
+                    if (file) formData.append('file', file, file.name);
+                    if (existingDocId) formData.append('existing_document_id', existingDocId);
+
+                    submitButton.textContent = 'Completing...';
+                    const response = await fetch('handle_complete_manifest.php', { method: 'POST', body: formData });
+                    const result = await response.json();
+
+                    if (result.success) {
+                        window.location = 'manifest_summary.php?id=' + result.manifest_id + '&completed=1';
+                    } else {
+                        showToast(result.message || 'Failed to complete the manifest.', 'error');
+                        submitButton.disabled = false;
+                        submitButton.textContent = 'Complete Manifest';
+                    }
+                } catch (error) {
+                    showToast('Error: ' + error.message, 'error');
+                    submitButton.disabled = false;
+                    submitButton.textContent = 'Complete Manifest';
+                }
+            });
+        </script>
+<?php endif; ?>
+    </main>
+
+<?php require 'footer.php'; ?>

--- a/grace_addon/files/general/www/public/dashboard.php
+++ b/grace_addon/files/general/www/public/dashboard.php
@@ -8,6 +8,7 @@ $stats = [
     'flowerOnHand' => 0,
     'sentThisMonthGrams' => 0,
     'sentThisMonthPlants' => 0,
+    'manifestsInProgress' => 0,
 ];
 $expiringLicenses = [];
 $companyName = '';
@@ -41,6 +42,8 @@ try {
                              AND date_harvested BETWEEN :startDate AND :endDate");
     $stmt->execute([':startDate' => $startDate, ':endDate' => $endDate]);
     $stats['sentThisMonthPlants'] = (int) $stmt->fetchColumn();
+
+    $stats['manifestsInProgress'] = (int) $pdo->query("SELECT COUNT(*) FROM ShippingManifests WHERE status = 'In Progress'")->fetchColumn();
 
     // Licenses expiring within 30 days (or already expired)
     $horizon = date('Y-m-d', strtotime('+30 days'));
@@ -83,6 +86,10 @@ require 'header.php';
             <a class="stat-card stat-card--link" href="this_months_flower_transactions.php">
                 <span class="stat-value"><?php echo formatGrams($stats['sentThisMonthGrams']); ?> g<?php if ($stats['sentThisMonthPlants'] > 0): ?> + <?php echo $stats['sentThisMonthPlants']; ?> plants<?php endif; ?></span>
                 <span class="stat-label">Materials out this month</span>
+            </a>
+            <a class="stat-card stat-card--link" href="complete_manifest.php">
+                <span class="stat-value"><?php echo $stats['manifestsInProgress']; ?></span>
+                <span class="stat-label">Manifests awaiting CoC</span>
             </a>
         </div>
 

--- a/grace_addon/files/general/www/public/download.php
+++ b/grace_addon/files/general/www/public/download.php
@@ -10,7 +10,7 @@ if (empty($category) || empty($filename)) {
 }
 
 // Allowed categories
-$allowedCategories = ['offtakes', 'sops', 'licenses', 'other_records', 'coc'];
+$allowedCategories = ['offtakes', 'sops', 'licenses', 'other_records', 'coc', 'manifests'];
 if (!in_array($category, $allowedCategories)) {
     die("Invalid category.");
 }

--- a/grace_addon/files/general/www/public/generate_shipping_manifest.php
+++ b/grace_addon/files/general/www/public/generate_shipping_manifest.php
@@ -16,6 +16,14 @@ $companies = $companiesStmt->fetchAll(PDO::FETCH_ASSOC);
 $geneticsStmt = $pdo->query("SELECT id, name FROM Genetics ORDER BY name ASC");
 $geneticsList = $geneticsStmt->fetchAll(PDO::FETCH_ASSOC);
 
+// Current dried-flower stock per genetics, so the form can show what an
+// automatic deduction will run against before the manifest is generated
+$stockStmt = $pdo->query("SELECT genetics_id, COALESCE(SUM(weight), 0) AS total FROM Flower GROUP BY genetics_id");
+$flowerStock = [];
+foreach ($stockStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+    $flowerStock[(int) $row['genetics_id']] = (float) $row['total'];
+}
+
 $pageTitle = 'GRACe - Generate Shipping Manifest';
 require 'header.php';
 ?>
@@ -25,6 +33,14 @@ require 'header.php';
             <h1>Generate Shipping Manifest</h1>
             <p>Create a manifest for plants or flower moving between license holders.</p>
         </hgroup>
+
+        <article class="form-card">
+            <p><strong>How this works:</strong> generating a manifest records it as <span class="badge badge--drying">In Progress</span>.
+            If you are sending <strong>flower</strong> to an external company, the shipped weight is
+            <strong>automatically deducted from your dried-flower inventory</strong> the moment the manifest is generated —
+            no separate ledger entry is needed. The manifest stays In Progress until the signed Chain of Custody
+            (photo or PDF) is attached on the <a href="complete_manifest.php">Complete Manifest</a> page.</p>
+        </article>
 
         <article class="form-card">
             <form id="shippingManifestForm" class="form" method="post" action="process_shipping_manifest.php">
@@ -53,17 +69,18 @@ require 'header.php';
                     <option value="plant">Plant</option>
                 </select>
 
-                <label for="quantity">Quantity or Weight:</label>
-                <input type="number" id="quantity" name="quantity" class="input" min="1" step="0.01" required>
+                <label for="quantity">Quantity or Weight (grams for flower):</label>
+                <input type="number" id="quantity" name="quantity" class="input" min="0.01" step="0.01" required>
 
-                <label for="geneticsName">Genetics:</label>
-                <select id="geneticsName" name="geneticsName" class="input" required>
+                <label for="geneticsId">Genetics:</label>
+                <select id="geneticsId" name="geneticsId" class="input" required>
                     <?php foreach ($geneticsList as $genetic): ?>
-                        <option value="<?php echo htmlspecialchars($genetic['name']); ?>">
+                        <option value="<?php echo (int) $genetic['id']; ?>">
                             <?php echo htmlspecialchars($genetic['name']); ?>
                         </option>
                     <?php endforeach; ?>
                 </select>
+                <small id="stockHint"></small>
 
                 <button type="submit" class="button">Generate Manifest</button>
             </form>
@@ -76,57 +93,66 @@ require 'header.php';
 
         const ownCompany = <?php echo json_encode($ownCompany); ?>;
         const companies = <?php echo json_encode($companies); ?>;
+        const flowerStock = <?php echo json_encode($flowerStock); ?>;
 
-        const populateDetails = (choice, detailElementId) => {
+        // Surface processing errors (e.g. insufficient stock) sent back via query string
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.get('error')) {
+            document.addEventListener('DOMContentLoaded', () => showToast(urlParams.get('error'), 'error', 8000));
+        }
+
+        // prefix distinguishes the sending fields from the receiving fields so
+        // both sides can be external without the POSTed values clobbering each other
+        const populateDetails = (choice, detailElementId, prefix) => {
             const detailElement = document.getElementById(detailElementId);
             detailElement.innerHTML = ''; // clear previous details
 
             if (choice === 'us') {
                 detailElement.innerHTML = `
-                    <label for="companyName">Company Name:</label>
-                    <input type="text" name="companyName" class="input" value="${ownCompany.company_name}" readonly>
+                    <label>Company Name:</label>
+                    <input type="text" name="${prefix}CompanyName" class="input" value="${ownCompany.company_name}" readonly>
 
-                    <label for="licenseNumber">License #:</label>
-                    <input type="text" name="licenseNumber" class="input" value="${ownCompany.company_license_number}" readonly>
+                    <label>License #:</label>
+                    <input type="text" name="${prefix}LicenseNumber" class="input" value="${ownCompany.company_license_number}" readonly>
 
-                    <label for="address">Address:</label>
-                    <textarea name="address" class="input" rows="2" readonly>${ownCompany.company_address}</textarea>
+                    <label>Address:</label>
+                    <textarea name="${prefix}Address" class="input" rows="2" readonly>${ownCompany.company_address}</textarea>
 
-                    <label for="contactEmail">Contact Email:</label>
-                    <input type="email" name="contactEmail" class="input" value="${ownCompany.primary_contact_email}" readonly>
+                    <label>Contact Email:</label>
+                    <input type="email" name="${prefix}ContactEmail" class="input" value="${ownCompany.primary_contact_email}" readonly>
                 `;
             } else {
-                let options = '<label for="companySelect">Select Company:</label>';
-                options += '<select id="companySelect" name="companySelect" class="input" required>';
+                let options = '<label>Select Company:</label>';
+                options += `<select name="${prefix}CompanySelect" class="input" required>`;
                 companies.forEach(company => {
                     options += `<option value="${company.id}">${company.name}</option>`;
                 });
                 options += '</select>';
                 detailElement.innerHTML = options;
 
-                const companySelect = detailElement.querySelector('#companySelect');
+                const companySelect = detailElement.querySelector('select');
                 companySelect.addEventListener('change', function() {
-                    updateExternalDetails(this, detailElement);
+                    updateExternalDetails(this, detailElement, prefix);
                 });
-                updateExternalDetails(companySelect, detailElement);
+                updateExternalDetails(companySelect, detailElement, prefix);
             }
         };
 
-        const updateExternalDetails = (selectElement, detailElement) => {
+        const updateExternalDetails = (selectElement, detailElement, prefix) => {
             let infoContainer = document.createElement('div');
             const selectedCompany = companies.find(company => company.id == selectElement.value);
             infoContainer.innerHTML = `
-                <label for="companyName">Company Name:</label>
-                <input type="text" name="companyName" class="input" value="${selectedCompany.name}" readonly>
+                <label>Company Name:</label>
+                <input type="text" name="${prefix}CompanyName" class="input" value="${selectedCompany.name}" readonly>
 
-                <label for="licenseNumber">License #:</label>
-                <input type="text" name="licenseNumber" class="input" value="${selectedCompany.license_number}" readonly>
+                <label>License #:</label>
+                <input type="text" name="${prefix}LicenseNumber" class="input" value="${selectedCompany.license_number}" readonly>
 
-                <label for="address">Address:</label>
-                <textarea name="address" class="input" rows="2" readonly>${selectedCompany.address}</textarea>
+                <label>Address:</label>
+                <textarea name="${prefix}Address" class="input" rows="2" readonly>${selectedCompany.address}</textarea>
 
-                <label for="contactEmail">Contact Email:</label>
-                <input type="email" name="contactEmail" class="input" value="${selectedCompany.primary_contact_email}" readonly>
+                <label>Contact Email:</label>
+                <input type="email" name="${prefix}ContactEmail" class="input" value="${selectedCompany.primary_contact_email}" readonly>
             `;
             // Remove any previous appended company details
                 const existingDetails = detailElement.querySelector('div');
@@ -138,16 +164,38 @@ require 'header.php';
                 detailElement.appendChild(infoContainer);
             };
 
+        // Show the recorded dried-flower stock the automatic deduction will run against
+        const productType = document.getElementById('productType');
+        const geneticsSelect = document.getElementById('geneticsId');
+        const stockHint = document.getElementById('stockHint');
+
+        const updateStockHint = () => {
+            const deductionApplies = productType.value === 'flower' && sendingChoice.value === 'us' && receivingChoice.value === 'external';
+            if (productType.value !== 'flower' || !geneticsSelect.value) {
+                stockHint.textContent = '';
+                return;
+            }
+            const grams = flowerStock[geneticsSelect.value] || 0;
+            const name = geneticsSelect.options[geneticsSelect.selectedIndex].text.trim();
+            stockHint.textContent = `Recorded dried-flower stock for ${name}: ${grams} g` +
+                (deductionApplies ? ' — the manifest weight will be deducted from this automatically.' : '');
+        };
+
+        [productType, geneticsSelect].forEach(el => el.addEventListener('change', updateStockHint));
+
         sendingChoice.addEventListener('change', () => {
-            populateDetails(sendingChoice.value, 'sendingDetails');
+            populateDetails(sendingChoice.value, 'sendingDetails', 'sending');
+            updateStockHint();
         });
 
         receivingChoice.addEventListener('change', () => {
-            populateDetails(receivingChoice.value, 'receivingDetails');
+            populateDetails(receivingChoice.value, 'receivingDetails', 'receiving');
+            updateStockHint();
         });
 
         // Initialize with default options
-        populateDetails(sendingChoice.value, 'sendingDetails');
-        populateDetails(receivingChoice.value, 'receivingDetails');
+        populateDetails(sendingChoice.value, 'sendingDetails', 'sending');
+        populateDetails(receivingChoice.value, 'receivingDetails', 'receiving');
+        updateStockHint();
     </script>
 <?php require 'footer.php'; ?>

--- a/grace_addon/files/general/www/public/handle_complete_manifest.php
+++ b/grace_addon/files/general/www/public/handle_complete_manifest.php
@@ -1,0 +1,91 @@
+<?php
+require_once 'init_db.php';
+require_once 'manifest_lib.php';
+
+$pdo = initializeDatabase();
+
+header('Content-Type: application/json');
+
+function respond($success, $message, $extra = []) {
+    echo json_encode(array_merge(['success' => $success, 'message' => $message], $extra));
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    respond(false, 'Invalid request');
+}
+
+$manifestId = (int) ($_POST['manifest_id'] ?? 0);
+$manifest = fetchManifest($pdo, $manifestId);
+
+if (!$manifest) {
+    respond(false, 'Manifest not found');
+}
+if ($manifest['status'] === 'Completed') {
+    respond(false, 'Manifest #' . $manifestId . ' is already completed');
+}
+
+$existingDocId = (int) ($_POST['existing_document_id'] ?? 0);
+$hasUpload = isset($_FILES['file']) && $_FILES['file']['error'] !== UPLOAD_ERR_NO_FILE;
+
+// Hard rule: a manifest cannot be closed off without a Chain of Custody attached
+if (!$hasUpload && !$existingDocId) {
+    respond(false, 'A Chain of Custody photo or PDF must be attached before the manifest can be completed.');
+}
+
+$cocDocumentId = null;
+
+if ($hasUpload) {
+    $file = $_FILES['file'];
+    if ($file['error'] !== UPLOAD_ERR_OK) {
+        respond(false, 'Upload failed (error code ' . $file['error'] . ')');
+    }
+    if (!is_uploaded_file($file['tmp_name'])) {
+        respond(false, 'File upload validation failed. The file may exceed nginx 1MB limit.');
+    }
+    if ($file['size'] > 1024 * 1024) {
+        respond(false, 'File too large. Maximum size is 1MB. Please compress or resize your image before uploading.');
+    }
+
+    $extension = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+    if (!in_array($extension, ['jpg', 'jpeg', 'png', 'gif', 'webp', 'pdf'], true)) {
+        respond(false, 'Chain of Custody must be a photo (jpg, png, gif, webp) or a PDF.');
+    }
+
+    $uploadDir = '/data/uploads/coc';
+    if (!is_dir($uploadDir) && !mkdir($uploadDir, 0777, true)) {
+        respond(false, 'Failed to create upload directory');
+    }
+
+    $uniqueName = uniqid() . '-' . basename($file['name']);
+    if (!move_uploaded_file($file['tmp_name'], $uploadDir . '/' . $uniqueName)) {
+        respond(false, 'Failed to save uploaded file. Please check directory permissions.');
+    }
+
+    $stmt = $pdo->prepare("INSERT INTO Documents (category, original_filename, unique_filename, upload_date, acknowledged) VALUES ('coc', ?, ?, ?, 0)");
+    $stmt->execute([$file['name'], $uniqueName, date('Y-m-d H:i:s')]);
+    $cocDocumentId = (int) $pdo->lastInsertId();
+} else {
+    // Attach an existing manually-uploaded CoC document — it must exist and
+    // not already be covering another manifest
+    $stmt = $pdo->prepare("SELECT id FROM Documents
+                           WHERE id = ? AND category = 'coc'
+                             AND id NOT IN (SELECT coc_document_id FROM ShippingManifests WHERE coc_document_id IS NOT NULL)");
+    $stmt->execute([$existingDocId]);
+    if (!$stmt->fetch()) {
+        respond(false, 'Selected Chain of Custody document is unavailable or already attached to another manifest.');
+    }
+    $cocDocumentId = $existingDocId;
+}
+
+// status guard in the WHERE clause protects against a double submit
+$stmt = $pdo->prepare("UPDATE ShippingManifests
+                       SET status = 'Completed', coc_document_id = ?, date_completed = ?
+                       WHERE id = ? AND status = 'In Progress'");
+$stmt->execute([$cocDocumentId, date('Y-m-d H:i:s'), $manifestId]);
+
+if ($stmt->rowCount() === 0) {
+    respond(false, 'Manifest could not be completed — it may have been completed already.');
+}
+
+respond(true, 'Manifest completed', ['manifest_id' => $manifestId]);

--- a/grace_addon/files/general/www/public/header.php
+++ b/grace_addon/files/general/www/public/header.php
@@ -7,7 +7,7 @@
  *   $useJquery  - set true on pages that use the jQuery document manager
  */
 if (!defined('GRACE_ASSET_VERSION')) {
-    define('GRACE_ASSET_VERSION', '0.15.1');
+    define('GRACE_ASSET_VERSION', '0.16.0');
 }
 $pageTitle = $pageTitle ?? 'GRACe';
 ?>

--- a/grace_addon/files/general/www/public/init_db.php
+++ b/grace_addon/files/general/www/public/init_db.php
@@ -81,6 +81,16 @@ function initializeDatabase($dbPath = '/data/grace.db') {
                 net_weight DECIMAL(10, 2),
                 gross_weight DECIMAL(10, 2),
                 manifest_file TEXT,
+                status TEXT NOT NULL DEFAULT 'In Progress',
+                sending_company_name TEXT,
+                receiving_company_name TEXT,
+                genetics_id INTEGER,
+                genetics_name TEXT,
+                quantity DECIMAL(10, 2),
+                destination_address TEXT,
+                flower_transaction_id INTEGER,
+                coc_document_id INTEGER,
+                date_completed DATETIME,
                 FOREIGN KEY (sending_company_id) REFERENCES Companies(id) ON DELETE SET NULL ON UPDATE CASCADE,
                 FOREIGN KEY (recipient_id) REFERENCES Companies(id) ON DELETE SET NULL ON UPDATE CASCADE
             );",
@@ -134,6 +144,16 @@ function initializeDatabase($dbPath = '/data/grace.db') {
     }
 }
 
+// Add a column to a table if it doesn't exist yet (in-place upgrade helper)
+function addColumnIfMissing($pdo, $table, $column, $ddl) {
+    try {
+        $pdo->query("SELECT $column FROM $table LIMIT 1");
+    } catch (PDOException $e) {
+        // Column doesn't exist, add it
+        $pdo->exec("ALTER TABLE $table ADD COLUMN $ddl");
+    }
+}
+
 // Function to perform migrations
 function performMigrations($pdo) {
     // Check for expiry_date column in Documents
@@ -158,6 +178,24 @@ function performMigrations($pdo) {
     } catch (PDOException $e) {
         // Column doesn't exist, add it
         $pdo->exec("ALTER TABLE Documents ADD COLUMN upload_date DATETIME DEFAULT CURRENT_TIMESTAMP");
+    }
+
+    // ShippingManifests workflow columns (added in 0.16.0 for the
+    // In Progress -> Completed manifest lifecycle with Chain of Custody)
+    $manifestColumns = [
+        'status' => "status TEXT NOT NULL DEFAULT 'In Progress'",
+        'sending_company_name' => "sending_company_name TEXT",
+        'receiving_company_name' => "receiving_company_name TEXT",
+        'genetics_id' => "genetics_id INTEGER",
+        'genetics_name' => "genetics_name TEXT",
+        'quantity' => "quantity DECIMAL(10, 2)",
+        'destination_address' => "destination_address TEXT",
+        'flower_transaction_id' => "flower_transaction_id INTEGER",
+        'coc_document_id' => "coc_document_id INTEGER",
+        'date_completed' => "date_completed DATETIME",
+    ];
+    foreach ($manifestColumns as $column => $ddl) {
+        addColumnIfMissing($pdo, 'ShippingManifests', $column, $ddl);
     }
 
     // Check Plants table constraint for new Harvest statuses
@@ -218,7 +256,7 @@ function performMigrations($pdo) {
 
 // Function to ensure directories exist
 function ensureUploadDirectories($baseDir = '/data/uploads/') {
-    $categories = ['offtakes', 'sops', 'licenses', 'other_records', 'coc'];
+    $categories = ['offtakes', 'sops', 'licenses', 'other_records', 'coc', 'manifests'];
 
     if (!is_dir($baseDir)) {
         if (!mkdir($baseDir, 0755, true)) {

--- a/grace_addon/files/general/www/public/manifest_lib.php
+++ b/grace_addon/files/general/www/public/manifest_lib.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * manifest_lib.php
+ *
+ * Shared helpers for the shipping manifest workflow pages:
+ * - manifest_summary.php (exchange summary)
+ * - complete_manifest.php (list + complete In Progress manifests)
+ * - handle_complete_manifest.php (attach CoC + close out)
+ * - chain_of_custody_documents.php (exchange list)
+ */
+
+const MANIFEST_SELECT = "SELECT SM.*,
+            D.original_filename AS coc_filename,
+            D.unique_filename AS coc_unique_filename,
+            F.weight AS deducted_weight,
+            F.transaction_date AS deduction_date
+        FROM ShippingManifests SM
+        LEFT JOIN Documents D ON SM.coc_document_id = D.id
+        LEFT JOIN Flower F ON SM.flower_transaction_id = F.id";
+
+function fetchManifest($pdo, $id) {
+    $stmt = $pdo->prepare(MANIFEST_SELECT . " WHERE SM.id = ?");
+    $stmt->execute([(int) $id]);
+    return $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+}
+
+function fetchManifests($pdo, $status = null) {
+    $sql = MANIFEST_SELECT;
+    $params = [];
+    if ($status !== null) {
+        $sql .= " WHERE SM.status = ?";
+        $params[] = $status;
+    }
+    $sql .= " ORDER BY SM.shipment_date DESC, SM.id DESC";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+/** "200 g White Widow (flower)" / "5 x GG4 (plant)" */
+function manifestShipmentLabel($manifest) {
+    $quantity = rtrim(rtrim(number_format((float) $manifest['quantity'], 2, '.', ''), '0'), '.');
+    $genetics = $manifest['genetics_name'] ?? '';
+    if ($manifest['product_type'] === 'flower') {
+        return "$quantity g $genetics (flower)";
+    }
+    return "$quantity x $genetics (plant)";
+}
+
+/** "Sender → Receiver" */
+function manifestRouteLabel($manifest) {
+    return ($manifest['sending_company_name'] ?? '?') . ' → ' . ($manifest['receiving_company_name'] ?? '?');
+}
+
+/** Status rendered as a coloured badge (HTML, pre-escaped). */
+function manifestStatusBadge($manifest) {
+    $status = $manifest['status'] ?? 'In Progress';
+    $class = $status === 'Completed' ? 'badge--growing' : 'badge--drying';
+    return '<span class="badge ' . $class . '">' . htmlspecialchars($status) . '</span>';
+}

--- a/grace_addon/files/general/www/public/manifest_summary.php
+++ b/grace_addon/files/general/www/public/manifest_summary.php
@@ -1,0 +1,101 @@
+<?php
+require_once 'init_db.php';
+require_once 'manifest_lib.php';
+
+$pdo = initializeDatabase();
+$manifest = fetchManifest($pdo, $_GET['id'] ?? 0);
+
+$pageTitle = 'GRACe - Manifest Summary';
+require 'header.php';
+?>
+
+    <main class="container">
+        <hgroup class="page-header">
+            <h1>Manifest Summary</h1>
+            <p>Source, destination and details of the exchange.</p>
+        </hgroup>
+
+<?php if (!$manifest): ?>
+        <article class="form-card">
+            <p>Manifest not found.</p>
+            <p><a href="complete_manifest.php">Back to Complete Manifest</a></p>
+        </article>
+<?php else: ?>
+        <article class="form-card">
+            <h2>Manifest #<?php echo (int) $manifest['id']; ?> <?php echo manifestStatusBadge($manifest); ?></h2>
+            <figure class="table-wrap">
+                <table>
+                    <tbody>
+                        <tr><td><strong>Prepared</strong></td><td><?php echo htmlspecialchars($manifest['shipment_date']); ?></td></tr>
+                        <tr><td><strong>Sending party</strong></td><td><?php echo htmlspecialchars($manifest['sending_company_name']); ?></td></tr>
+                        <tr><td><strong>Receiving party</strong></td><td><?php echo htmlspecialchars($manifest['receiving_company_name']); ?></td></tr>
+                        <tr><td><strong>Destination address</strong></td><td><?php echo nl2br(htmlspecialchars($manifest['destination_address'] ?? '')); ?></td></tr>
+                        <tr><td><strong>Shipment</strong></td><td><?php echo htmlspecialchars(manifestShipmentLabel($manifest)); ?></td></tr>
+                        <tr>
+                            <td><strong>Inventory deduction</strong></td>
+                            <td>
+                                <?php if ($manifest['flower_transaction_id']): ?>
+                                    <?php echo htmlspecialchars(abs((float) $manifest['deducted_weight']) . ' g deducted from the dried-flower ledger on ' . $manifest['deduction_date']); ?>
+                                <?php elseif ($manifest['product_type'] === 'flower'): ?>
+                                    None — this shipment was not sent from our inventory.
+                                <?php else: ?>
+                                    n/a (plants are processed out via Harvest / Destroy / Send)
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><strong>Chain of Custody</strong></td>
+                            <td>
+                                <?php if ($manifest['coc_document_id']): ?>
+                                    <a href="download.php?category=coc&file=<?php echo urlencode($manifest['coc_unique_filename']); ?>" download>
+                                        <?php echo htmlspecialchars($manifest['coc_filename']); ?>
+                                    </a>
+                                <?php else: ?>
+                                    <span class="badge badge--drying">Not yet attached</span>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                        <tr><td><strong>Completed</strong></td><td><?php echo $manifest['date_completed'] ? htmlspecialchars($manifest['date_completed']) : '—'; ?></td></tr>
+                        <tr>
+                            <td><strong>Manifest PDF</strong></td>
+                            <td>
+                                <?php if ($manifest['manifest_file']): ?>
+                                    <a href="download.php?category=manifests&file=<?php echo urlencode($manifest['manifest_file']); ?>" download>Download manifest PDF</a>
+                                <?php else: ?>
+                                    —
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </figure>
+
+            <?php if ($manifest['status'] !== 'Completed'): ?>
+                <a href="complete_manifest.php?id=<?php echo (int) $manifest['id']; ?>" role="button">Complete this manifest</a>
+            <?php endif; ?>
+        </article>
+
+        <p>
+            <a href="complete_manifest.php">All manifests awaiting completion</a> ·
+            <a href="chain_of_custody_documents.php">Chain of Custody documents</a>
+        </p>
+
+        <script>
+            const urlParams = new URLSearchParams(window.location.search);
+            document.addEventListener('DOMContentLoaded', () => {
+                if (urlParams.get('created')) {
+                    <?php if ($manifest['flower_transaction_id']): ?>
+                    showToast('Manifest #<?php echo (int) $manifest['id']; ?> created — <?php echo abs((float) $manifest['deducted_weight']); ?> g deducted from dried-flower inventory. Attach the Chain of Custody to complete it.', 'success', 8000);
+                    <?php else: ?>
+                    showToast('Manifest #<?php echo (int) $manifest['id']; ?> created as In Progress. Attach the Chain of Custody to complete it.', 'success', 8000);
+                    <?php endif; ?>
+                }
+                if (urlParams.get('completed')) {
+                    showToast('Manifest #<?php echo (int) $manifest['id']; ?> completed — Chain of Custody attached.', 'success');
+                }
+            });
+        </script>
+<?php endif; ?>
+    </main>
+
+<?php require 'footer.php'; ?>

--- a/grace_addon/files/general/www/public/nav.php
+++ b/grace_addon/files/general/www/public/nav.php
@@ -8,7 +8,7 @@ $navSections = [
     ],
     'tracking.php' => [
         'label' => 'Plant Tracking',
-        'pages' => ['tracking', 'list_all_genetics', 'receive_genetics', 'harvest_plants', 'record_dry_weight', 'generate_shipping_manifest'],
+        'pages' => ['tracking', 'list_all_genetics', 'receive_genetics', 'harvest_plants', 'record_dry_weight', 'generate_shipping_manifest', 'complete_manifest', 'manifest_summary'],
     ],
     'reporting.php' => [
         'label' => 'Reporting',
@@ -27,7 +27,7 @@ $navSections = [
                 </span>
                 <span class="nav-brand-text">
                     <strong>GRACe</strong>
-                    <span class="nav-brand-sub">by Chill Division <small>v0.15.1</small></span>
+                    <span class="nav-brand-sub">by Chill Division <small>v0.16.0</small></span>
                 </span>
             </a>
             <input type="checkbox" id="nav-toggle" class="nav-toggle">

--- a/grace_addon/files/general/www/public/process_shipping_manifest.php
+++ b/grace_addon/files/general/www/public/process_shipping_manifest.php
@@ -1,124 +1,143 @@
 <?php
-session_start();
 require_once 'TCPDF/tcpdf.php';
 require_once 'init_db.php';
 
 // Initialize PDO connection
 $pdo = initializeDatabase();
 
-// Fetch OwnCompany details
-$ownCompanyStmt = $pdo->query("SELECT company_name, company_license_number, company_address, primary_contact_email FROM OwnCompany LIMIT 1");
-$ownCompany = $ownCompanyStmt->fetch(PDO::FETCH_ASSOC);
-
-// Fetch list of external companies
-$companiesStmt = $pdo->query("SELECT id, name, license_number, address, primary_contact_email FROM Companies");
-$companies = $companiesStmt->fetchAll(PDO::FETCH_ASSOC);
-
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $_SESSION['formData'] = $_POST;
-    $sendingChoice = $_POST['sendingChoice'] ?? "";
-    $receivingChoice = $_POST['receivingChoice'] ?? "";
-    $productType = $_POST['productType']?? "";
-    $quantity = $_POST['quantity']?? "";
-    $address = $_POST['address']?? "";
-    $geneticsName = $_POST['geneticsName']?? "";
-    $datePrepared = date('Y-m-d H:i:s')?? "";
-    
-    // Handling sending company data
-    if ($sendingChoice === 'us') {
-        $sendingCompany = $ownCompany['company_name'];
-        $sendingLicense = $ownCompany['company_license_number'];
-        $sendingEmail = $ownCompany['primary_contact_email'];
-    } else {
-        $sendingCompanyId = $_POST['companySelect'];
-        $sendingCompanyData = $pdo->prepare("SELECT name, license_number, primary_contact_email FROM Companies WHERE id = ?");
-        $sendingCompanyData->execute([$sendingCompanyId]);
-        $sendingCompanyInfo = $sendingCompanyData->fetch(PDO::FETCH_ASSOC);
-
-        $sendingCompany = $sendingCompanyInfo['name'] ?? "";
-        $sendingLicense = $sendingCompanyInfo['license_number'] ?? "";
-        $sendingEmail = $sendingCompanyInfo['primary_contact_email'] ?? "";
-    }
-
-    // Handling receiving company data
-    if ($receivingChoice === 'us') {
-        $receivingCompany = $ownCompany['company_name'];
-        $receivingLicense = $ownCompany['company_license_number'];
-        $receivingEmail = $ownCompany['primary_contact_email'];
-    } else {
-        $receivingCompanyId = $_POST['companySelect'];
-        $receivingCompanyData = $pdo->prepare("SELECT name, license_number, primary_contact_email FROM Companies WHERE id = ?");
-        $receivingCompanyData->execute([$receivingCompanyId]);
-        $receivingCompanyInfo = $receivingCompanyData->fetch(PDO::FETCH_ASSOC);
-
-        $receivingCompany = $receivingCompanyInfo['name'] ?? "";
-        $receivingLicense = $receivingCompanyInfo['license_number'] ?? "";
-        $receivingEmail = $receivingCompanyInfo['primary_contact_email'] ?? "";
-    }
-} elseif (isset($_SESSION['formData'])) {
-    // Retrieve session data on refresh
-    $formData = $_SESSION['formData'];
-    $sendingChoice = $formData['sendingChoice']?? "";
-    $receivingChoice = $formData['receivingChoice']?? "";
-    $productType = $formData['productType']?? "";
-    $quantity = $formData['quantity']?? "";
-    $address = $formData['address']?? "";
-    $geneticsName = $formData['geneticsName']?? "";
-    $datePrepared = date('Y-m-d H:i:s')?? "";
-
-    if ($sendingChoice === 'us') {
-        $sendingCompany = $ownCompany['company_name'];
-        $sendingLicense = $ownCompany['company_license_number'];
-        $sendingEmail = $ownCompany['primary_contact_email'];
-    } else {
-        $sendingCompanyId = $formData['companySelect'];
-        $sendingCompanyData = $pdo->prepare("SELECT name, license_number, primary_contact_email FROM Companies WHERE id = ?");
-        $sendingCompanyData->execute([$sendingCompanyId]);
-        $sendingCompanyInfo = $sendingCompanyData->fetch(PDO::FETCH_ASSOC);
-
-        $sendingCompany = $sendingCompanyInfo['name'] ?? "";
-        $sendingLicense = $sendingCompanyInfo['license_number'] ?? "";
-        $sendingEmail = $sendingCompanyInfo['primary_contact_email'] ?? "";
-    }
-
-    if ($receivingChoice === 'us') {
-        $receivingCompany = $ownCompany['company_name'];
-        $receivingLicense = $ownCompany['company_license_number'];
-        $receivingEmail = $ownCompany['primary_contact_email'];
-    } else {
-        $receivingCompanyId = $formData['companySelect'];
-        $receivingCompanyData = $pdo->prepare("SELECT name, license_number, primary_contact_email FROM Companies WHERE id = ?");
-        $receivingCompanyData->execute([$receivingCompanyId]);
-        $receivingCompanyInfo = $receivingCompanyData->fetch(PDO::FETCH_ASSOC);
-
-        $receivingCompany = $receivingCompanyInfo['name'] ?? "";
-        $receivingLicense = $receivingCompanyInfo['license_number'] ?? "";
-        $receivingEmail = $receivingCompanyInfo['primary_contact_email'] ?? "";
-    }
-} else {
-    header("Location: process_shipping_manifest.php");
+// Manifests are only ever created from the generate form (POST). A stray GET
+// (refresh, bookmark) just goes back to the form — nothing is written twice.
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: generate_shipping_manifest.php');
     exit();
 }
 
-$formattedAddress = nl2br(htmlspecialchars($address));
-
-// Create PDF object
-$pdf = new TCPDF(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false);
-$pdf->SetCreator(PDF_CREATOR);
-$pdf->SetAuthor('Chill Division');
-$pdf->SetTitle('Shipping Manifest');
-$pdf->SetMargins(15, 15, 15);
-$pdf->SetHeaderMargin(15);
-$pdf->AddPage();
-// Add company logo
-$logoPath = $_SERVER['DOCUMENT_ROOT'] . '/GRACe_repo/grace_addon/logo.png';
-$logoWebPath = '/GRACe_repo/grace_addon/logo.png';
-if (file_exists($logoPath)) {
-    $pdf->Image($logoPath, 160, 22, 30, 0, 'PNG');
+function backToFormWithError($message) {
+    header('Location: generate_shipping_manifest.php?error=' . urlencode($message));
+    exit();
 }
 
-// Define HTML structure
-$htmlContent = <<<EOD
+// Fetch OwnCompany details
+$ownCompanyStmt = $pdo->query("SELECT company_name, company_license_number, company_address, primary_contact_email FROM OwnCompany LIMIT 1");
+$ownCompany = $ownCompanyStmt->fetch(PDO::FETCH_ASSOC);
+if (!$ownCompany) {
+    backToFormWithError('Set up your own company details before generating a manifest.');
+}
+
+$sendingChoice = $_POST['sendingChoice'] ?? '';
+$receivingChoice = $_POST['receivingChoice'] ?? '';
+$productType = $_POST['productType'] ?? '';
+$quantity = (float) ($_POST['quantity'] ?? 0);
+$geneticsId = (int) ($_POST['geneticsId'] ?? 0);
+
+if (!in_array($sendingChoice, ['us', 'external'], true)
+    || !in_array($receivingChoice, ['us', 'external'], true)
+    || !in_array($productType, ['flower', 'plant'], true)
+    || $quantity <= 0) {
+    backToFormWithError('All manifest fields are required.');
+}
+
+$geneticsStmt = $pdo->prepare("SELECT id, name FROM Genetics WHERE id = ?");
+$geneticsStmt->execute([$geneticsId]);
+$genetics = $geneticsStmt->fetch(PDO::FETCH_ASSOC);
+if (!$genetics) {
+    backToFormWithError('Please select a valid genetics.');
+}
+
+// Resolve a party (sending or receiving) to a consistent shape
+function resolveParty($pdo, $ownCompany, $choice, $companyId) {
+    if ($choice === 'us') {
+        return [
+            'id' => null,
+            'name' => $ownCompany['company_name'],
+            'license' => $ownCompany['company_license_number'],
+            'email' => $ownCompany['primary_contact_email'],
+            'address' => $ownCompany['company_address'],
+        ];
+    }
+    $stmt = $pdo->prepare("SELECT id, name, license_number, address, primary_contact_email FROM Companies WHERE id = ?");
+    $stmt->execute([(int) $companyId]);
+    $company = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$company) {
+        return null;
+    }
+    return [
+        'id' => (int) $company['id'],
+        'name' => $company['name'],
+        'license' => $company['license_number'],
+        'email' => $company['primary_contact_email'],
+        'address' => $company['address'],
+    ];
+}
+
+$sender = resolveParty($pdo, $ownCompany, $sendingChoice, $_POST['sendingCompanySelect'] ?? 0);
+$receiver = resolveParty($pdo, $ownCompany, $receivingChoice, $_POST['receivingCompanySelect'] ?? 0);
+if (!$sender || !$receiver) {
+    backToFormWithError('Please select a valid company for both parties.');
+}
+
+// Automatic inventory deduction: flower leaving us for an external company
+// comes straight off the dried-flower ledger as part of generating the manifest
+$deductFlower = ($productType === 'flower' && $sendingChoice === 'us' && $receivingChoice === 'external');
+
+if ($deductFlower) {
+    $stockStmt = $pdo->prepare("SELECT COALESCE(SUM(weight), 0) FROM Flower WHERE genetics_id = ?");
+    $stockStmt->execute([$geneticsId]);
+    $stock = (float) $stockStmt->fetchColumn();
+    if ($quantity > $stock) {
+        backToFormWithError(sprintf(
+            'Insufficient dried flower for %s: %.2f g recorded, manifest needs %.2f g. Correct the ledger before generating the manifest.',
+            $genetics['name'], $stock, $quantity
+        ));
+    }
+}
+
+$datePrepared = date('Y-m-d H:i:s');
+
+try {
+    $pdo->beginTransaction();
+
+    $flowerTransactionId = null;
+    if ($deductFlower) {
+        // Reason must be exactly 'Send external' so the deduction shows up in
+        // the monthly Agency report and dashboard totals like a manual entry
+        $flowerStmt = $pdo->prepare("INSERT INTO Flower (genetics_id, weight, transaction_type, transaction_date, reason, company_id)
+                                     VALUES (?, ?, 'Subtract', ?, 'Send external', ?)");
+        $flowerStmt->execute([$geneticsId, -$quantity, $datePrepared, $receiver['id']]);
+        $flowerTransactionId = (int) $pdo->lastInsertId();
+    }
+
+    $manifestStmt = $pdo->prepare("INSERT INTO ShippingManifests
+        (sending_company_id, recipient_id, shipment_date, product_type, status,
+         sending_company_name, receiving_company_name, genetics_id, genetics_name,
+         quantity, destination_address, flower_transaction_id)
+        VALUES (?, ?, ?, ?, 'In Progress', ?, ?, ?, ?, ?, ?, ?)");
+    $manifestStmt->execute([
+        $sender['id'], $receiver['id'], $datePrepared, $productType,
+        $sender['name'], $receiver['name'], $geneticsId, $genetics['name'],
+        $quantity, $receiver['address'], $flowerTransactionId,
+    ]);
+    $manifestId = (int) $pdo->lastInsertId();
+
+    // --- Build the manifest PDF and persist it so it can be re-downloaded later ---
+    $pdf = new TCPDF(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false);
+    $pdf->SetCreator(PDF_CREATOR);
+    $pdf->SetAuthor('Chill Division');
+    $pdf->SetTitle('Shipping Manifest');
+    $pdf->SetMargins(15, 15, 15);
+    $pdf->SetHeaderMargin(15);
+    $pdf->AddPage();
+
+    $senderName = htmlspecialchars($sender['name'] ?? '');
+    $senderLicense = htmlspecialchars($sender['license'] ?? '');
+    $senderEmail = htmlspecialchars($sender['email'] ?? '');
+    $receiverName = htmlspecialchars($receiver['name'] ?? '');
+    $receiverLicense = htmlspecialchars($receiver['license'] ?? '');
+    $geneticsName = htmlspecialchars($genetics['name']);
+    $formattedAddress = nl2br(htmlspecialchars($receiver['address'] ?? ''));
+    $quantityLabel = $productType === 'flower' ? $quantity . ' g' : $quantity;
+
+    $htmlContent = <<<EOD
 
     <style>
          h1 { color: #85bbe9; text-align: left; font-weight: bold; }
@@ -132,23 +151,25 @@ $htmlContent = <<<EOD
             <h1>Chill Division Universal Shipping Manifest</h1>
         </div>
     </div>
-    
+
     <h2>Sending Party:</h2>
     <table>
-        <tr><td><strong>Staff Name Preparing Shipment:</strong></td><td><u>{$sendingChoice}</u></td></tr>
-        <tr><td><strong>Sending Company name + Licence #:</strong></td><td><u>{$sendingCompany} / {$sendingLicense}</u></td></tr>
-        <tr><td><strong>Arrival Notification Email:</strong></td><td><u>{$sendingEmail}</u></td></tr>
+        <tr><td><strong>Manifest #:</strong></td><td><u>{$manifestId}</u></td></tr>
+        <tr><td><strong>Staff Name Preparing Shipment:</strong></td><td>________________________</td></tr>
+        <tr><td><strong>Sending Company name + Licence #:</strong></td><td><u>{$senderName} / {$senderLicense}</u></td></tr>
+        <tr><td><strong>Arrival Notification Email:</strong></td><td><u>{$senderEmail}</u></td></tr>
         <tr><td><strong>Date / Time Prepared for shipment:</strong></td><td><u>{$datePrepared}</u></td></tr>
         <tr><td><strong>Product Type:</strong></td><td><u>{$productType}</u></td></tr>
-        <tr><td><strong># of Items Sent:</strong></td><td><u>{$quantity}</u></td></tr>
+        <tr><td><strong>Genetics:</strong></td><td><u>{$geneticsName}</u></td></tr>
+        <tr><td><strong># of Items Sent:</strong></td><td><u>{$quantityLabel}</u></td></tr>
         <tr><td><strong>Shipment Weight (Net / Gross):</strong></td><td>________________________</td></tr>
         <tr><td><strong>Recipient Staff Name:</strong></td><td>________________________</td></tr>
-        <tr><td><strong>Recipient Company + Licence #:</strong></td><td><u>{$receivingCompany} / {$receivingLicense}</u></td></tr>
+        <tr><td><strong>Recipient Company + Licence #:</strong></td><td><u>{$receiverName} / {$receiverLicense}</u></td></tr>
         <tr><td><strong>Destination Address:</strong></td><td><u>{$formattedAddress}</u></td></tr>
     </table>
 
     <p class="signature"><strong>• Staff Signature:</strong> ________________________</p>
-    
+
     <h2>Transit Chain of Custody (if applicable):</h2>
     <table class="ms-[30px]">
         <tr><td><strong>Collected from Facility By:</strong></td><td>________________________</td></tr>
@@ -162,74 +183,41 @@ $htmlContent = <<<EOD
     <h2>Receiving Party:</h2>
     <table class="ms-[30px]">
         <tr><td><strong>Received By (Staff Name):</strong></td><td>________________________</td></tr>
-        <tr><td><strong>Date / Time of Receipt:</strong></td><td><u>{$datePrepared}</u></td></tr>
-        <tr><td><strong># of Items Received:</strong></td><td><u>{$quantity}</u></td></tr>
+        <tr><td><strong>Date / Time of Receipt:</strong></td><td>____/____/______ ____:____</td></tr>
+        <tr><td><strong># of Items Received:</strong></td><td>________________________</td></tr>
         <tr><td><strong>Shipment Weight (Net / Gross):</strong></td><td>________________________</td></tr>
     </table>
 
     <p class="signature"><strong>• Signature of Receiving Party:</strong>________________________</p>
 
-    <p><em>Please scan/photo upon receipt of goods and send a copy to <strong>{$sendingEmail}</strong></em></p>
+    <p><em>Please scan/photo upon receipt of goods and send a copy to <strong>{$senderEmail}</strong></em></p>
+    <p><em>This manifest is recorded as In Progress (manifest #{$manifestId}) in GRACe. It must be completed with the
+    signed Chain of Custody attached once the shipment is received.</em></p>
     EOD;
 
-// Add content to PDF
-// $pdfHtmlContent = str_replace("padding-top: 5px;", "", $htmlContent);
-$pdf->writeHTML($htmlContent, true, false, true, false, '');
-$pdfOutput = $pdf->Output('shipping_manifest.pdf', 'S');
+    $pdf->writeHTML($htmlContent, true, false, true, false, '');
+    $pdfOutput = $pdf->Output('shipping_manifest.pdf', 'S');
 
-?>
-<!doctype html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">  
-
-    <meta name="color-scheme" content="light dark">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">  
-
-    <link rel="stylesheet" href="css/growcart.css">
-    <title>GRACe - Plant Tracking</title>
-    <!-- <script src="https://cdn.tailwindcss.com"></script> -->
-</head>
-<style>
-    .heading {
-        text-align: center;
-        margin-bottom: 30px;
+    $manifestDir = '/data/uploads/manifests';
+    if (!is_dir($manifestDir)) {
+        mkdir($manifestDir, 0777, true);
+    }
+    $manifestFile = uniqid() . '-shipping-manifest-' . $manifestId . '.pdf';
+    if (file_put_contents($manifestDir . '/' . $manifestFile, $pdfOutput) === false) {
+        throw new Exception('Failed to write the manifest PDF to disk.');
     }
 
-    .main_box{
-        border: 1px solid #fff;
-        border-radius: 20px;
-        padding: 40px;
-        margin-bottom: 40px;
-    }
+    $pdo->prepare("UPDATE ShippingManifests SET manifest_file = ? WHERE id = ?")
+        ->execute([$manifestFile, $manifestId]);
 
-    [data-theme="dark"] .main_box {
-        border-color: white;
+    $pdo->commit();
+} catch (Exception $e) {
+    $pdo->rollBack();
+    if (isset($manifestFile) && file_exists($manifestDir . '/' . $manifestFile)) {
+        @unlink($manifestDir . '/' . $manifestFile);
     }
+    backToFormWithError('Error generating manifest: ' . $e->getMessage());
+}
 
-    [data-theme="light"] .main_box {
-        border-color: black;
-    }
-</style>
-
-<body>
-    <header class="container-fluid">
-        <?php require_once 'nav.php'; ?>
-    </header>
-    <main class="container p-6  rounded-lg w-full max-w-2xl">
-        <h1 class="heading text-[43px] font-bold text-center  mb-[40px]">Your Shipping Manifest</h1>
-        <div class="main_box p-6 border border-gray-200 rounded-lg text-gray-700">
-            <p><?php echo $htmlContent; ?></p>
-        </div>
-        <form method="post" action="download_pdf.php" class="mt-6 flex justify-center">
-            <input type="hidden" name="pdfContent" value="<?php echo base64_encode($pdfOutput); ?>">
-            <button type="submit" class="px-6 py-2 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition duration-300">
-                Download as PDF
-            </button>
-        </form>
-    </main>
-    <script src="js/growcart.js"></script>
-</body>
-</html>
+header('Location: manifest_summary.php?id=' . $manifestId . '&created=1');
+exit();

--- a/grace_addon/files/general/www/public/tracking.php
+++ b/grace_addon/files/general/www/public/tracking.php
@@ -53,14 +53,13 @@ require 'header.php';
                         <small>Create a manifest PDF for plants or flower leaving your site</small>
                     </span>
                 </a>
-                <div class="nav-card is-disabled" aria-disabled="true">
+                <a class="nav-card" href="complete_manifest.php">
                     <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="m9 15 2 2 4-4"/></svg></span>
                     <span class="nav-card-body">
-                        <strong>Amend / Complete Manifest</strong>
-                        <small>Update or finalise a manifest already in transit</small>
-                        <span class="badge-soon">Coming soon</span>
+                        <strong>Complete Manifest</strong>
+                        <small>Attach the signed Chain of Custody and close out a manifest in transit</small>
                     </span>
-                </div>
+                </a>
             </div>
         </section>
 

--- a/tests/seed_demo_data.php
+++ b/tests/seed_demo_data.php
@@ -67,7 +67,7 @@ function buildDemoPdf($title)
     return $pdf;
 }
 
-/** Insert a document row + matching file on disk so download links work. */
+/** Insert a document row + matching file on disk so download links work. Returns the document id. */
 function seedDocument($pdo, $uploadDir, $category, $originalName, $daysAgoUploaded, $expiryDate = null)
 {
     $uniqueName = uniqid('demo_', true) . '.pdf';
@@ -80,6 +80,19 @@ function seedDocument($pdo, $uploadDir, $category, $originalName, $daysAgoUpload
     $stmt = $pdo->prepare("INSERT INTO Documents (category, original_filename, unique_filename, upload_date, expiry_date, acknowledged)
                            VALUES (?, ?, ?, datetime('now', ?), ?, 0)");
     $stmt->execute([$category, $originalName, $uniqueName, "-$daysAgoUploaded days", $expiryDate]);
+    return (int) $pdo->lastInsertId();
+}
+
+/** Write a demo manifest PDF into uploads/manifests and return its unique filename. */
+function seedManifestPdf($uploadDir, $manifestLabel)
+{
+    $dir = $uploadDir . 'manifests';
+    if (!is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+    $uniqueName = uniqid('demo_', true) . '-shipping-manifest.pdf';
+    file_put_contents($dir . '/' . $uniqueName, buildDemoPdf($manifestLabel));
+    return $uniqueName;
 }
 
 $pdo->beginTransaction();
@@ -155,13 +168,40 @@ seedDocument($pdo, $uploadDir, 'sops', 'SOP-pest-management.pdf', 90);
 seedDocument($pdo, $uploadDir, 'sops', 'SOP-harvest-procedure.pdf', 60);
 seedDocument($pdo, $uploadDir, 'offtakes', 'offtake-agreement-aotearoa.pdf', 150);
 seedDocument($pdo, $uploadDir, 'other_records', 'police-vet-check-grower.pdf', 45);
-seedDocument($pdo, $uploadDir, 'coc', 'coc-shipment-2026-05.pdf', 12);
+$cocDocId = seedDocument($pdo, $uploadDir, 'coc', 'coc-shipment-2026-05.pdf', 12);
+
+// --- Shipping manifests (one completed, one awaiting its CoC) ----------------
+// Completed: matches the 200g White Widow "Send external" ledger entry above
+$sentFlowerId = (int) $pdo->query("SELECT id FROM Flower WHERE reason = 'Send external' AND weight = -200.00")->fetchColumn();
+$manifestStmt = $pdo->prepare("INSERT INTO ShippingManifests
+    (sending_company_id, recipient_id, shipment_date, product_type, status,
+     sending_company_name, receiving_company_name, genetics_id, genetics_name,
+     quantity, destination_address, flower_transaction_id, coc_document_id, date_completed, manifest_file)
+    VALUES (?, ?, datetime('now', ?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+$manifestStmt->execute([
+    null, 2, '-3 days', 'flower', 'Completed',
+    'Demo Cultivation Co', 'Aotearoa Offtake Partners', 2, 'White Widow',
+    200.00, '45 Harbour View, Auckland 1010', $sentFlowerId, $cocDocId, date('Y-m-d H:i:s', strtotime('-1 day')),
+    seedManifestPdf($uploadDir, 'shipping-manifest-white-widow-200g.pdf'),
+]);
+
+// In Progress: a fresh GG4 shipment, flower already deducted, CoC still pending
+$pdo->prepare("INSERT INTO Flower (genetics_id, weight, transaction_type, reason, transaction_date, company_id)
+               VALUES (3, -50.00, 'Subtract', 'Send external', datetime('now', '-1 days'), 2)")->execute();
+$pendingFlowerId = (int) $pdo->lastInsertId();
+$manifestStmt->execute([
+    null, 2, '-1 days', 'flower', 'In Progress',
+    'Demo Cultivation Co', 'Aotearoa Offtake Partners', 3, 'GG4',
+    50.00, '45 Harbour View, Auckland 1010', $pendingFlowerId, null, null,
+    seedManifestPdf($uploadDir, 'shipping-manifest-gg4-50g.pdf'),
+]);
 
 $pdo->commit();
 
 echo "Demo data seeded into $dbPath\n";
 echo "  - 1 own company, 3 external companies, 5 genetics\n";
 echo "  - " . count($plantRows) . " plants (growing / drying / destroyed / sent)\n";
-echo "  - " . count($flowerRows) . " flower ledger entries\n";
+echo "  - " . (count($flowerRows) + 1) . " flower ledger entries\n";
 echo "  - 7 documents with downloadable demo PDFs in {$uploadDir}\n";
+echo "  - 2 shipping manifests (1 completed with CoC attached, 1 awaiting completion)\n";
 echo "  - 1 license expiring in ~10 days (exercises the expiry banner + dashboard warning)\n";

--- a/tests/test_db_migration.php
+++ b/tests/test_db_migration.php
@@ -40,6 +40,19 @@ try {
     }
     echo "[PASS] All columns verified (including upload_date, expiry_date)\n";
 
+    // Check manifest workflow columns in ShippingManifests (added 0.16.0)
+    $manifestColumns = ['status', 'sending_company_name', 'receiving_company_name', 'genetics_id',
+                        'genetics_name', 'quantity', 'destination_address', 'flower_transaction_id',
+                        'coc_document_id', 'date_completed'];
+    foreach ($manifestColumns as $col) {
+        try {
+            $pdo->query("SELECT $col FROM ShippingManifests LIMIT 1");
+        } catch (PDOException $e) {
+            throw new Exception("Column '$col' missing in ShippingManifests table");
+        }
+    }
+    echo "[PASS] ShippingManifests workflow columns verified\n";
+
     // 3. Test Upgrade Scenario (Mocking an old DB)
     echo "Testing Upgrade from v0.10 (Missing columns)...\n";
     $upgradeDb = tempnam(sys_get_temp_dir(), 'grace_test_upgrade_db');
@@ -49,14 +62,30 @@ try {
     // Create old schema (missing upload_date, expiry_date, acknowledged)
     $pdoUpgrade->exec("CREATE TABLE IF NOT EXISTS Documents (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
-        category TEXT NOT NULL, 
+        category TEXT NOT NULL,
         original_filename TEXT NOT NULL,
         unique_filename TEXT NOT NULL
     );");
-    
+
+    // Old ShippingManifests schema (pre-0.16.0, no workflow columns), with a
+    // pre-existing row to prove the in-place upgrade preserves data
+    $pdoUpgrade->exec("CREATE TABLE IF NOT EXISTS ShippingManifests (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        sender_id INTEGER,
+        sending_company_id INTEGER,
+        recipient_id INTEGER,
+        shipment_date DATETIME DEFAULT CURRENT_TIMESTAMP,
+        product_type TEXT,
+        item_count INTEGER,
+        net_weight DECIMAL(10, 2),
+        gross_weight DECIMAL(10, 2),
+        manifest_file TEXT
+    );");
+    $pdoUpgrade->exec("INSERT INTO ShippingManifests (product_type, item_count) VALUES ('flower', 3)");
+
     // Run migrations
     performMigrations($pdoUpgrade);
-    
+
     // Verify columns were added
     $columns = ['upload_date', 'expiry_date', 'acknowledged'];
     foreach ($columns as $col) {
@@ -67,7 +96,26 @@ try {
         }
     }
     echo "[PASS] Database Upgrade from v0.10 verified (All columns added)\n";
-    
+
+    // Verify ShippingManifests workflow columns were added in place
+    foreach ($manifestColumns as $col) {
+        try {
+            $pdoUpgrade->query("SELECT $col FROM ShippingManifests LIMIT 1");
+        } catch (PDOException $e) {
+            throw new Exception("Upgrade Failed: Column '$col' was not added to ShippingManifests table");
+        }
+    }
+
+    // Pre-existing row must survive with the In Progress default backfilled
+    $row = $pdoUpgrade->query("SELECT product_type, item_count, status FROM ShippingManifests")->fetch(PDO::FETCH_ASSOC);
+    if (!$row || $row['product_type'] !== 'flower' || (int) $row['item_count'] !== 3) {
+        throw new Exception("Upgrade Failed: pre-existing ShippingManifests row was lost or altered");
+    }
+    if ($row['status'] !== 'In Progress') {
+        throw new Exception("Upgrade Failed: status default not backfilled (got '{$row['status']}')");
+    }
+    echo "[PASS] ShippingManifests upgraded in place (columns added, data preserved)\n";
+
     // Cleanup upgrade DB
     unset($pdoUpgrade);
     unlink($upgradeDb);

--- a/tests/test_permissions.php
+++ b/tests/test_permissions.php
@@ -19,7 +19,7 @@ try {
     }
 
     // Verify Subdirectories
-    $categories = ['offtakes', 'sops', 'licenses', 'other_records', 'coc'];
+    $categories = ['offtakes', 'sops', 'licenses', 'other_records', 'coc', 'manifests'];
     foreach ($categories as $cat) {
         $catDir = $tempDir . '/' . $cat;
         if (!is_dir($catDir)) {


### PR DESCRIPTION
## What this does

Shipping manifests are now tracked end-to-end instead of being a fire-and-forget PDF.

### Generate (existing page, reworked)
- `generate_shipping_manifest.php` now tells the user up front that generating a manifest will **automatically deduct the shipped flower** from the dried-flower ledger, and shows the recorded stock for the selected genetics.
- On generation the manifest is recorded as **In Progress**. Flower sent from us to an external company is deducted immediately (reason `Send external`, so the monthly Agency report and dashboard totals pick it up exactly like a manual ledger entry). Generation is blocked if the manifest weight exceeds recorded stock.
- Processing is now a single POST → redirect flow (refresh can't double-generate), and the manifest PDF is persisted to `/data/uploads/manifests/` for later re-download. The PDF gains the manifest #, genetics, and a note that it must be completed in GRACe.

### Complete Manifest (new page)
- `complete_manifest.php` lists every uncompleted manifest with **date, destination, and what was shipped**, so the right one can be chosen for completion.
- Completing requires attaching the signed **Chain of Custody (photo or PDF)** — uploaded directly, or picked from documents already uploaded on the Chain of Custody page. **A manifest cannot be closed off without a CoC attached** (enforced server-side in `handle_complete_manifest.php`, including a double-submit guard and a one-CoC-per-manifest rule).
- Per the brief this is *Complete* only — no amending of manifests in transit.

### Exchange summary (new page)
- `manifest_summary.php` shows source / destination / shipment details, the inventory deduction, the attached CoC, and the manifest PDF for each exchange. Linked from both the Chain of Custody page and the Complete Manifest page.

### Chain of Custody page
- Manual standalone CoC uploads work exactly as before. The page now also lists all shipment exchanges with their status and CoC state, each linking to its summary.

### Database — safe in-place upgrade
- `ShippingManifests` gains `status`, party-name snapshots, `genetics_id`/`genetics_name`, `quantity`, `destination_address`, `flower_transaction_id`, `coc_document_id`, `date_completed` via `performMigrations()` (`ALTER TABLE ... ADD COLUMN`, same pattern as the existing Documents migrations). Existing installations with data upgrade automatically on first page load — no manual steps, no data loss.
- `tests/test_db_migration.php` now covers this: fresh-install column check, plus an upgrade simulation from the pre-0.16 schema with a pre-existing row asserting columns are added, data survives, and the `In Progress` default is backfilled.

### Also
- Dashboard stat: "Manifests awaiting CoC" linking to Complete Manifest.
- Tracking hub: "Amend / Complete Manifest — coming soon" card replaced with a live **Complete Manifest** card.
- Form fix: sending/receiving party fields no longer share input names, so external→external manifests record both companies correctly (previously the receiver silently overwrote the sender). The PDF also no longer prints the literal "us"/"external" as the preparing staff name.
- Demo seed data gains two manifests (one completed, one awaiting CoC); DOCS.md gains a "Shipping & Chain of Custody" user guide section.

## Version bump (per DEVELOPMENT.md release checklist)
- `config.yaml` → `0.16.0`
- `nav.php` → `v0.16.0`
- `CHANGELOG.md` → `## [0.16.0]`
- `GRACE_ASSET_VERSION` in `header.php` → `0.16.0`

## Testing
- `bash tests/run_ci.sh` — **all checks pass** (DB migrations incl. new ShippingManifests upgrade tests, permissions incl. new `manifests` upload dir, static checks, version consistency, PHP syntax across every file).
- Manually verified end-to-end against a seeded dev DB (PHP 8.1 + SQLite, per DEVELOPMENT.md): manifest generation deducts flower and lands In Progress with the PDF on disk; over-stock generation is rejected with a clear error; completion without a CoC is refused; completion via direct upload and via an existing CoC document both work; double-completion and reuse of an already-linked CoC are refused; plant and external→external manifests create no deduction; all five touched pages render and the persisted PDF downloads as `application/pdf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)