### PR TITLE
Release 0.16.1: Fix annual stocktake counting long-departed plants as opening stock

### DIFF
--- a/grace_addon/CHANGELOG.md
+++ b/grace_addon/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.16.1] - 2026-06-12
+### Fixed
+- **Annual Stocktake opening balance**: plants that left stock more than one year before the report year (destroyed / sent / legacy-harvested) kept appearing in the Start Amount and End columns forever. The old query only subtracted departures dated within the *immediately previous* year, so e.g. a plant destroyed in 2024 still showed as stock-on-hand in the 2026 report. The opening balance is now "created before 1 Jan and not departed before 1 Jan", regardless of which year the departure happened. The report's End total now reconciles exactly with live stock (Growing + Drying).
+- **Annual Stocktake 31-December boundary**: plant and flower activity timestamped on 31 December after midnight (e.g. `2026-12-31 14:00`) was silently dropped from the year's In/Out/Destroyed columns because datetimes were string-compared against a plain `YYYY-12-31` upper bound. All date comparisons now use `DATE(...)` with an exclusive 1-January upper bound.
+- 'Harvested - Drying' plants harvested in an earlier year are now consistently treated as active stock in the opening balance (matching how the End column has treated them since 0.14).
+
+### Refactor
+- Stocktake calculations extracted to `annual_stocktake_lib.php`, shared by both report endpoints and covered by a new regression test (`tests/test_annual_stocktake.php`, wired into `tests/run_ci.sh`).
+
 ## [0.16.0] - 2026-06-12
 ### Added
 - **Manifest lifecycle**: Generating a shipping manifest now records it in the ledger as **In Progress**. It stays In Progress until the signed Chain of Custody (photo or PDF) is attached — a manifest cannot be completed without one (enforced server-side).

--- a/grace_addon/config.yaml
+++ b/grace_addon/config.yaml
@@ -1,7 +1,7 @@
 name: "GRACe Portal"
 description: "Growers Regulatory Assistance & Compliance engine"
 url: "https://www.chilldivision.co.nz"
-version: "0.16.0"
+version: "0.16.1"
 slug: "grace_addon"
 panel_icon: mdi:cannabis
 init: false

--- a/grace_addon/files/general/www/public/annual_stocktake_lib.php
+++ b/grace_addon/files/general/www/public/annual_stocktake_lib.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Annual stocktake calculations, shared by the report endpoints
+ * (get_annual_plant_stocktake.php / get_annual_flower_stocktake.php)
+ * and the regression tests (tests/test_annual_stocktake.php).
+ *
+ * Date handling: date_created / date_harvested / transaction_date are stored
+ * as 'YYYY-MM-DD HH:MM:SS' datetimes, so all comparisons wrap them in DATE()
+ * and compare against exclusive year boundaries — a plain string BETWEEN
+ * '...-01-01' AND '...-12-31' silently drops anything timestamped on
+ * 31 December after midnight.
+ */
+
+// Statuses that mean a plant has left stock. 'Harvested - Drying' is
+// deliberately absent: drying plants count as active stock (since 0.14).
+const GRACE_PLANT_DEPARTED_STATUSES = ['Sent', 'Harvested', 'Harvested - Destroyed', 'Destroyed'];
+
+/**
+ * Per-genetics plant stocktake for one calendar year.
+ *
+ * Start amount = plants created before 1 Jan that had not left stock before
+ * 1 Jan — regardless of WHICH earlier year they left in. (Pre-0.16.1 this
+ * only subtracted departures dated in the immediately-previous year, so a
+ * plant destroyed two or more years ago kept appearing in the opening
+ * balance forever.)
+ *
+ * @return array[] rows of geneticsName/startAmount/in/out/harvested/destroyed/end
+ */
+function computeAnnualPlantStocktake(PDO $pdo, int $year): array
+{
+    $startDate = sprintf('%04d-01-01', $year);       // first day of the report year
+    $nextStartDate = sprintf('%04d-01-01', $year + 1); // exclusive upper bound
+
+    $departedList = "'" . implode("','", GRACE_PLANT_DEPARTED_STATUSES) . "'";
+
+    $genetics = $pdo->query("SELECT id, name FROM Genetics ORDER BY name ASC")->fetchAll(PDO::FETCH_ASSOC);
+
+    $rows = [];
+    foreach ($genetics as $genetic) {
+        // In stock at 00:00 on 1 Jan: created earlier, and either still an
+        // active status, or departed during/after the report year. Departed
+        // rows with no date_harvested can't be placed in time, so they're
+        // treated as already gone.
+        $stmt = $pdo->prepare(
+            "SELECT COUNT(*) FROM Plants
+             WHERE genetics_id = :geneticsId
+               AND DATE(date_created) < :startDate
+               AND (
+                    status NOT IN ($departedList)
+                    OR (date_harvested IS NOT NULL AND DATE(date_harvested) >= :startDate)
+               )"
+        );
+        $stmt->execute([':geneticsId' => $genetic['id'], ':startDate' => $startDate]);
+        $startAmount = (int) $stmt->fetchColumn();
+
+        // Created during the year
+        $stmt = $pdo->prepare(
+            "SELECT COUNT(*) FROM Plants
+             WHERE genetics_id = :geneticsId
+               AND DATE(date_created) >= :startDate AND DATE(date_created) < :nextStartDate"
+        );
+        $stmt->execute([':geneticsId' => $genetic['id'], ':startDate' => $startDate, ':nextStartDate' => $nextStartDate]);
+        $inCount = (int) $stmt->fetchColumn();
+
+        // Sent externally during the year (Out)
+        $stmt = $pdo->prepare(
+            "SELECT COUNT(*) FROM Plants
+             WHERE genetics_id = :geneticsId AND status = 'Sent'
+               AND date_harvested IS NOT NULL
+               AND DATE(date_harvested) >= :startDate AND DATE(date_harvested) < :nextStartDate"
+        );
+        $stmt->execute([':geneticsId' => $genetic['id'], ':startDate' => $startDate, ':nextStartDate' => $nextStartDate]);
+        $sentCount = (int) $stmt->fetchColumn();
+
+        // Legacy 'Harvested' during the year ("Harvested - Drying" stays in stock)
+        $stmt = $pdo->prepare(
+            "SELECT COUNT(*) FROM Plants
+             WHERE genetics_id = :geneticsId AND status = 'Harvested'
+               AND date_harvested IS NOT NULL
+               AND DATE(date_harvested) >= :startDate AND DATE(date_harvested) < :nextStartDate"
+        );
+        $stmt->execute([':geneticsId' => $genetic['id'], ':startDate' => $startDate, ':nextStartDate' => $nextStartDate]);
+        $harvestedCount = (int) $stmt->fetchColumn();
+
+        // Destroyed during the year
+        $stmt = $pdo->prepare(
+            "SELECT COUNT(*) FROM Plants
+             WHERE genetics_id = :geneticsId
+               AND status IN ('Destroyed', 'Harvested - Destroyed')
+               AND date_harvested IS NOT NULL
+               AND DATE(date_harvested) >= :startDate AND DATE(date_harvested) < :nextStartDate"
+        );
+        $stmt->execute([':geneticsId' => $genetic['id'], ':startDate' => $startDate, ':nextStartDate' => $nextStartDate]);
+        $destroyedCount = (int) $stmt->fetchColumn();
+
+        $rows[] = [
+            'geneticsName' => $genetic['name'],
+            'startAmount' => $startAmount,
+            'in' => $inCount,
+            'out' => $sentCount,
+            'harvested' => $harvestedCount,
+            'destroyed' => $destroyedCount,
+            'end' => $startAmount + $inCount - $sentCount - $harvestedCount - $destroyedCount,
+        ];
+    }
+
+    return $rows;
+}
+
+/**
+ * Per-genetics dried flower stocktake for one calendar year.
+ * The Flower table is a signed ledger, so the opening balance is simply the
+ * running sum of everything dated before 1 Jan.
+ *
+ * @return array[] rows of geneticsName/startWeight/in/out/destroyed/end
+ */
+function computeAnnualFlowerStocktake(PDO $pdo, int $year): array
+{
+    $startDate = sprintf('%04d-01-01', $year);
+    $nextStartDate = sprintf('%04d-01-01', $year + 1);
+
+    $genetics = $pdo->query("SELECT id, name FROM Genetics ORDER BY name ASC")->fetchAll(PDO::FETCH_ASSOC);
+
+    $rows = [];
+    foreach ($genetics as $genetic) {
+        $stmt = $pdo->prepare(
+            "SELECT COALESCE(SUM(weight), 0) FROM Flower
+             WHERE genetics_id = :geneticsId AND DATE(transaction_date) < :startDate"
+        );
+        $stmt->execute([':geneticsId' => $genetic['id'], ':startDate' => $startDate]);
+        $startWeight = floatval($stmt->fetchColumn());
+
+        $stmt = $pdo->prepare(
+            "SELECT COALESCE(SUM(weight), 0) FROM Flower
+             WHERE genetics_id = :geneticsId AND transaction_type = 'Add'
+               AND DATE(transaction_date) >= :startDate AND DATE(transaction_date) < :nextStartDate"
+        );
+        $stmt->execute([':geneticsId' => $genetic['id'], ':startDate' => $startDate, ':nextStartDate' => $nextStartDate]);
+        $inWeight = floatval($stmt->fetchColumn());
+
+        $stmt = $pdo->prepare(
+            "SELECT COALESCE(SUM(weight), 0) FROM Flower
+             WHERE genetics_id = :geneticsId AND transaction_type = 'Subtract'
+               AND reason IN ('Send external', 'Testing')
+               AND DATE(transaction_date) >= :startDate AND DATE(transaction_date) < :nextStartDate"
+        );
+        $stmt->execute([':geneticsId' => $genetic['id'], ':startDate' => $startDate, ':nextStartDate' => $nextStartDate]);
+        $outWeight = floatval($stmt->fetchColumn());
+
+        $stmt = $pdo->prepare(
+            "SELECT COALESCE(SUM(weight), 0) FROM Flower
+             WHERE genetics_id = :geneticsId AND transaction_type = 'Subtract'
+               AND reason NOT IN ('Send external', 'Testing')
+               AND DATE(transaction_date) >= :startDate AND DATE(transaction_date) < :nextStartDate"
+        );
+        $stmt->execute([':geneticsId' => $genetic['id'], ':startDate' => $startDate, ':nextStartDate' => $nextStartDate]);
+        $destroyedWeight = floatval($stmt->fetchColumn());
+
+        $rows[] = [
+            'geneticsName' => $genetic['name'],
+            'startWeight' => $startWeight,
+            'in' => $inWeight,
+            'out' => abs($outWeight),
+            'destroyed' => abs($destroyedWeight),
+            'end' => $startWeight + $inWeight - abs($outWeight) - abs($destroyedWeight),
+        ];
+    }
+
+    return $rows;
+}

--- a/grace_addon/files/general/www/public/get_annual_flower_stocktake.php
+++ b/grace_addon/files/general/www/public/get_annual_flower_stocktake.php
@@ -1,87 +1,14 @@
 <?php
 require_once 'init_db.php';
+require_once 'annual_stocktake_lib.php';
 
 try {
     $pdo = initializeDatabase();
 
     $selectedYear = isset($_GET['year']) ? intval($_GET['year']) : (date('Y') - 1);
 
-    $startDate = "{$selectedYear}-01-01";
-    $endDate = "{$selectedYear}-12-31";
-
-    $query = "SELECT id, name FROM Genetics ORDER BY name ASC";
-    $geneticsStmt = $pdo->query($query);
-    $genetics = $geneticsStmt->fetchAll(PDO::FETCH_ASSOC);
-
-    $flowerStocktakeData = [];
-
-    foreach ($genetics as $genetic) {
-        $startWeightQuery = "SELECT COALESCE(SUM(weight), 0) AS startWeight
-                             FROM Flower
-                             WHERE genetics_id = :geneticsId
-                             AND transaction_date < :startDate";
-        
-        $stmt = $pdo->prepare($startWeightQuery);
-        $stmt->bindParam(':geneticsId', $genetic['id'], PDO::PARAM_INT);
-        $stmt->bindParam(':startDate', $startDate, PDO::PARAM_STR);
-        $stmt->execute();
-        $startWeight = floatval($stmt->fetchColumn());
-
-        $inWeightQuery = "SELECT COALESCE(SUM(weight), 0) AS inWeight
-                          FROM Flower
-                          WHERE genetics_id = :geneticsId
-                          AND transaction_type = 'Add'
-                          AND transaction_date BETWEEN :startDate AND :endDate";
-        
-        $stmt = $pdo->prepare($inWeightQuery);
-        $stmt->bindParam(':geneticsId', $genetic['id'], PDO::PARAM_INT);
-        $stmt->bindParam(':startDate', $startDate, PDO::PARAM_STR);
-        $stmt->bindParam(':endDate', $endDate, PDO::PARAM_STR);
-        $stmt->execute();
-        $inWeight = floatval($stmt->fetchColumn());
-
-        $outWeightQuery = "SELECT COALESCE(SUM(weight), 0) AS outWeight
-                           FROM Flower
-                           WHERE genetics_id = :geneticsId
-                           AND transaction_type = 'Subtract'
-                           AND reason IN ('Send external', 'Testing')
-                           AND transaction_date BETWEEN :startDate AND :endDate";
-        
-        $stmt = $pdo->prepare($outWeightQuery);
-        $stmt->bindParam(':geneticsId', $genetic['id'], PDO::PARAM_INT);
-        $stmt->bindParam(':startDate', $startDate, PDO::PARAM_STR);
-        $stmt->bindParam(':endDate', $endDate, PDO::PARAM_STR);
-        $stmt->execute();
-        $outWeight = floatval($stmt->fetchColumn());
-
-        $destroyedWeightQuery = "SELECT COALESCE(SUM(weight), 0) AS destroyedWeight
-                                 FROM Flower
-                                 WHERE genetics_id = :geneticsId
-                                 AND transaction_type = 'Subtract'
-                                 AND reason NOT IN ('Send external', 'Testing')
-                                 AND transaction_date BETWEEN :startDate AND :endDate";
-        
-        $stmt = $pdo->prepare($destroyedWeightQuery);
-        $stmt->bindParam(':geneticsId', $genetic['id'], PDO::PARAM_INT);
-        $stmt->bindParam(':startDate', $startDate, PDO::PARAM_STR);
-        $stmt->bindParam(':endDate', $endDate, PDO::PARAM_STR);
-        $stmt->execute();
-        $destroyedWeight = floatval($stmt->fetchColumn());
-
-        $endWeight = $startWeight + $inWeight - abs($outWeight) - abs($destroyedWeight);
-
-        $flowerStocktakeData[] = [
-            'geneticsName' => $genetic['name'],
-            'startWeight' => $startWeight,
-            'in' => $inWeight,
-            'out' => abs($outWeight),
-            'destroyed' => abs($destroyedWeight),
-            'end' => $endWeight
-        ];
-    }
-
     header('Content-Type: application/json');
-    echo json_encode($flowerStocktakeData);
+    echo json_encode(computeAnnualFlowerStocktake($pdo, $selectedYear));
 } catch (PDOException $e) {
     http_response_code(500);
     echo json_encode(['error' => 'Database error: ' . htmlentities($e->getMessage())]);

--- a/grace_addon/files/general/www/public/get_annual_plant_stocktake.php
+++ b/grace_addon/files/general/www/public/get_annual_plant_stocktake.php
@@ -1,106 +1,14 @@
 <?php
 require_once 'init_db.php';
+require_once 'annual_stocktake_lib.php';
 
 try {
     $pdo = initializeDatabase();
 
     $selectedYear = isset($_GET['year']) ? intval($_GET['year']) : (date('Y') - 1);
 
-    $startDate = "{$selectedYear}-01-01";
-    $endDate = "{$selectedYear}-12-31";
-    
-    $previousYear = $selectedYear - 1;
-    $prevStartDate = "{$previousYear}-01-01";
-    $prevEndDate = "{$previousYear}-12-31";
-
-    $query = "SELECT id, name FROM Genetics ORDER BY name ASC";
-    $geneticsStmt = $pdo->query($query);
-    $genetics = $geneticsStmt->fetchAll(PDO::FETCH_ASSOC);
-
-    $plantStocktakeData = [];
-
-    foreach ($genetics as $genetic) {
-        // $startAmountQuery = "SELECT COUNT(*) AS startAmount
-        //                      FROM Plants
-        //                      WHERE genetics_id = :geneticsId
-        //                      AND date_created < :startDate";
-        
-        // $stmt = $pdo->prepare($startAmountQuery);
-        // $stmt->bindParam(':geneticsId', $genetic['id'], PDO::PARAM_INT);
-        // $stmt->bindParam(':startDate', $startDate, PDO::PARAM_STR);
-        // $stmt->execute();
-        // $startAmount = (int) $stmt->fetchColumn();
-        
-        $prevEndAmountQuery = "SELECT (COUNT(*) -
-                                  (SELECT COUNT(*) FROM Plants WHERE genetics_id = :geneticsId AND status IN ('Sent', 'Harvested', 'Harvested - Drying', 'Harvested - Destroyed', 'Destroyed') AND date_harvested BETWEEN :prevStartDate AND :prevEndDate)
-                                 ) AS prevEndAmount
-                              FROM Plants
-                              WHERE genetics_id = :geneticsId 
-                              AND date_created < :prevEndDate";
-        
-        $stmt = $pdo->prepare($prevEndAmountQuery);
-        $stmt->bindParam(':geneticsId', $genetic['id'], PDO::PARAM_INT);
-        $stmt->bindParam(':prevStartDate', $prevStartDate, PDO::PARAM_STR);
-        $stmt->bindParam(':prevEndDate', $prevEndDate, PDO::PARAM_STR);
-        $stmt->execute();
-        $startAmount = (int) $stmt->fetchColumn();
-
-        $inCountQuery = "SELECT COUNT(*) AS inCount
-                         FROM Plants
-                         WHERE genetics_id = :geneticsId
-                         AND date_created BETWEEN :startDate AND :endDate";
-
-        $stmt = $pdo->prepare($inCountQuery);
-        $stmt->bindParam(':geneticsId', $genetic['id'], PDO::PARAM_INT);
-        $stmt->bindParam(':startDate', $startDate, PDO::PARAM_STR);
-        $stmt->bindParam(':endDate', $endDate, PDO::PARAM_STR);
-        $stmt->execute();
-        $inCount = (int) $stmt->fetchColumn();
-
-        // Count 'Sent' plants (Out)
-        $sentCount = $pdo->prepare("SELECT COUNT(*) FROM Plants WHERE genetics_id = :geneticsId AND status = 'Sent' AND date_harvested BETWEEN :startDate AND :endDate");
-        $sentCount->bindParam(':geneticsId', $genetic['id'], PDO::PARAM_INT);
-        $sentCount->bindParam(':startDate', $startDate, PDO::PARAM_STR);
-        $sentCount->bindParam(':endDate', $endDate, PDO::PARAM_STR);
-        $sentCount->execute();
-        $sentCount = (int) $sentCount->fetchColumn();
-
-        // Count harvested plants (Legacy only - "Harvested - Drying" are considered active/in-stock, so excluded here)
-        $harvestedCount = $pdo->prepare("SELECT COUNT(*) FROM Plants WHERE genetics_id = :geneticsId AND status = 'Harvested' AND DATE(date_harvested) BETWEEN :startDate AND :endDate");
-        $harvestedCount->bindParam(':geneticsId', $genetic['id'], PDO::PARAM_INT);
-        $harvestedCount->bindParam(':startDate', $startDate, PDO::PARAM_STR);
-        $harvestedCount->bindParam(':endDate', $endDate, PDO::PARAM_STR);
-        $harvestedCount->execute();
-        $harvestedCount = (int) $harvestedCount->fetchColumn();
-
-        $destroyedCountQuery = "SELECT COUNT(*) AS destroyedCount
-                                FROM Plants
-                                WHERE genetics_id = :geneticsId
-                                AND status IN ('Destroyed', 'Harvested - Destroyed')
-                                AND DATE(date_harvested) BETWEEN :startDate AND :endDate";
-
-        $stmt = $pdo->prepare($destroyedCountQuery);
-        $stmt->bindParam(':geneticsId', $genetic['id'], PDO::PARAM_INT);
-        $stmt->bindParam(':startDate', $startDate, PDO::PARAM_STR);
-        $stmt->bindParam(':endDate', $endDate, PDO::PARAM_STR);
-        $stmt->execute();
-        $destroyedCount = (int) $stmt->fetchColumn();
-
-	$endAmount = $startAmount + $inCount - abs($sentCount) - abs($harvestedCount) - abs($destroyedCount);
-
-        $plantStocktakeData[] = [
-            'geneticsName' => $genetic['name'],
-            'startAmount' => $startAmount,
-            'in' => $inCount,
-            'out' => $sentCount,        // Use 'Sent' count for 'out'
-            'harvested' => $harvestedCount, // Add 'harvested' count
-            'destroyed' => $destroyedCount,
-            'end' => $endAmount
-        ];
-    }
-
     header('Content-Type: application/json');
-    echo json_encode($plantStocktakeData);
+    echo json_encode(computeAnnualPlantStocktake($pdo, $selectedYear));
 } catch (PDOException $e) {
     http_response_code(500);
     echo json_encode(['error' => 'Database error: ' . htmlentities($e->getMessage())]);

--- a/grace_addon/files/general/www/public/header.php
+++ b/grace_addon/files/general/www/public/header.php
@@ -7,7 +7,7 @@
  *   $useJquery  - set true on pages that use the jQuery document manager
  */
 if (!defined('GRACE_ASSET_VERSION')) {
-    define('GRACE_ASSET_VERSION', '0.16.0');
+    define('GRACE_ASSET_VERSION', '0.16.1');
 }
 $pageTitle = $pageTitle ?? 'GRACe';
 ?>

--- a/grace_addon/files/general/www/public/nav.php
+++ b/grace_addon/files/general/www/public/nav.php
@@ -27,7 +27,7 @@ $navSections = [
                 </span>
                 <span class="nav-brand-text">
                     <strong>GRACe</strong>
-                    <span class="nav-brand-sub">by Chill Division <small>v0.16.0</small></span>
+                    <span class="nav-brand-sub">by Chill Division <small>v0.16.1</small></span>
                 </span>
             </a>
             <input type="checkbox" id="nav-toggle" class="nav-toggle">

--- a/tests/run_ci.sh
+++ b/tests/run_ci.sh
@@ -36,6 +36,17 @@ else
     FAILures=$((FAILures+1))
 fi
 
+# Run Annual Stocktake Test
+echo ""
+echo "--- Annual Stocktake Test ---"
+php tests/test_annual_stocktake.php
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}[PASS]${NC} Annual stocktake logic verified"
+else
+    echo -e "${RED}[FAIL]${NC} Annual stocktake logic failed"
+    FAILures=$((FAILures+1))
+fi
+
 # Run Static Checks
 echo ""
 echo "--- Static Analysis ---"

--- a/tests/test_annual_stocktake.php
+++ b/tests/test_annual_stocktake.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Regression tests for the annual stocktake calculations
+ * (grace_addon/files/general/www/public/annual_stocktake_lib.php).
+ *
+ * Covers the 0.16.1 bug: plants that left stock MORE than one year before the
+ * report year kept appearing in the opening balance forever, because the old
+ * query only subtracted departures dated within the immediately-previous year.
+ * Also covers the 31-December boundary (datetime vs date string comparison)
+ * and "Harvested - Drying counts as active stock".
+ */
+
+$publicDir = __DIR__ . '/../grace_addon/files/general/www/public';
+require_once $publicDir . '/init_db.php';
+require_once $publicDir . '/annual_stocktake_lib.php';
+
+$tmpDb = tempnam(sys_get_temp_dir(), 'grace_stocktake_') . '.db';
+$pdo = initializeDatabase($tmpDb);
+
+$failures = 0;
+function check($label, $actual, $expected)
+{
+    global $failures;
+    if ($actual === $expected) {
+        echo "[PASS] $label\n";
+    } else {
+        echo "[FAIL] $label — expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n";
+        $failures++;
+    }
+}
+
+// Report year for all scenarios. Fixed (not relative to today) so results are deterministic.
+$year = 2026;
+
+$pdo->exec("INSERT INTO Genetics (name) VALUES ('Alpha'), ('Bravo')");
+
+// Alpha (genetics_id 1) — plant scenarios
+$pdo->exec("INSERT INTO Plants (genetics_id, status, date_created, date_harvested) VALUES
+    -- 1. THE BUG: destroyed two years before the report year -> must not be in 2026 at all
+    (1, 'Destroyed',             '2024-03-01 10:00:00', '2024-10-20 02:26:58'),
+    -- 2. destroyed in the immediately-previous year -> also not in 2026
+    (1, 'Harvested - Destroyed', '2025-02-01 10:00:00', '2025-06-15 09:00:00'),
+    -- 3. growing since 2023 -> in start and end
+    (1, 'Growing',               '2023-05-05 08:00:00', NULL),
+    -- 4. created during the report year -> 'in' and end
+    (1, 'Growing',               '2026-04-10 12:00:00', NULL),
+    -- 5. created 31 Dec of the report year, late in the day -> still 'in' (boundary)
+    (1, 'Growing',               '2026-12-31 23:30:00', NULL),
+    -- 6. created before, destroyed during the report year -> start + destroyed, not end
+    (1, 'Destroyed',             '2025-03-03 10:00:00', '2026-07-01 11:00:00'),
+    -- 7. created before, sent during the report year -> start + out, not end
+    (1, 'Sent',                  '2025-08-08 10:00:00', '2026-05-05 10:00:00'),
+    -- 8. harvested to drying BEFORE the report year -> drying is active stock, stays in start/end
+    (1, 'Harvested - Drying',    '2024-06-06 10:00:00', '2025-11-11 10:00:00'),
+    -- 9. legacy 'Harvested' before the report year -> left stock, not in start
+    (1, 'Harvested',             '2023-01-01 10:00:00', '2023-09-09 10:00:00')");
+
+// Bravo (genetics_id 2) — entirely departed before the report year (the 'Medicine Girl' case)
+$pdo->exec("INSERT INTO Plants (genetics_id, status, date_created, date_harvested) VALUES
+    (2, 'Destroyed', '2023-02-02 10:00:00', '2024-01-15 10:00:00'),
+    (2, 'Sent',      '2023-02-02 10:00:00', '2024-02-20 10:00:00')");
+
+$rows = computeAnnualPlantStocktake($pdo, $year);
+$byName = [];
+foreach ($rows as $r) {
+    $byName[$r['geneticsName']] = $r;
+}
+
+$a = $byName['Alpha'];
+// In stock at 2026-01-01: #3 growing, #6 destroyed-during-2026, #7 sent-during-2026, #8 drying => 4
+check('Alpha start excludes plants departed in ANY earlier year', $a['startAmount'], 4);
+check('Alpha in counts 2026 creations incl. 31 Dec evening', $a['in'], 2);
+check('Alpha out (sent during 2026)', $a['out'], 1);
+check('Alpha destroyed during 2026', $a['destroyed'], 1);
+check('Alpha legacy harvested in 2026 is zero', $a['harvested'], 0);
+// end = 4 + 2 - 1 - 0 - 1 = 4 (#3, #4, #5, #8)
+check('Alpha end balance', $a['end'], 4);
+
+$b = $byName['Bravo'];
+check('Bravo (all departed before 2026) start is zero', $b['startAmount'], 0);
+check('Bravo end is zero', $b['end'], 0);
+check('Bravo shows zero activity in 2026', $b['in'] + $b['out'] + $b['harvested'] + $b['destroyed'], 0);
+
+// --- Flower ledger scenarios -------------------------------------------------
+$pdo->exec("INSERT INTO Flower (genetics_id, weight, transaction_type, reason, transaction_date) VALUES
+    (1,  500.00, 'Add',      'Harvest',       '2025-09-01 10:00:00'),  -- before the year -> start
+    (1, -100.00, 'Subtract', 'Send external', '2025-10-01 10:00:00'),  -- before the year -> start
+    (1,  250.00, 'Add',      'Harvest',       '2026-03-01 10:00:00'),  -- in
+    (1,  -50.00, 'Subtract', 'Testing',       '2026-06-01 10:00:00'),  -- out
+    (1,  -20.00, 'Subtract', 'Destroy',       '2026-12-31 18:00:00'),  -- destroyed, 31 Dec boundary
+    (1,   10.00, 'Add',      'Harvest',       '2027-01-02 10:00:00')   -- next year -> ignored");
+
+$rows = computeAnnualFlowerStocktake($pdo, $year);
+$f = null;
+foreach ($rows as $r) {
+    if ($r['geneticsName'] === 'Alpha') {
+        $f = $r;
+    }
+}
+
+check('Flower start is the running balance before 1 Jan', $f['startWeight'], 400.0);
+check('Flower in during the year', $f['in'], 250.0);
+check('Flower out during the year', $f['out'], 50.0);
+check('Flower destroyed incl. 31 Dec evening', $f['destroyed'], 20.0);
+check('Flower end balance', $f['end'], 580.0);
+
+unlink($tmpDb);
+
+if ($failures > 0) {
+    echo "[FAIL] Annual stocktake tests: $failures failure(s)\n";
+    exit(1);
+}
+echo "[PASS] Annual Stocktake Test Completed Successfully\n";
+exit(0);


### PR DESCRIPTION
## The bug

The Annual Stocktake's **Start Amount** was computed as:

> plants created before 31 Dec of the previous year **minus** departures dated *within the previous year only*

So a plant that was destroyed/sent/legacy-harvested in any **earlier** year was never subtracted — it reappeared in the opening balance of every later report, forever. Example: running the 2026 report, a plant destroyed in 2024 still shows as 2026 stock-on-hand, because only departures dated in 2025 were subtracted. The longer an installation has been running, the more inflated the Start Amount and End columns become, and genetics with no remaining plants at all keep appearing in the report.

## The fix

Start Amount is now: **created before 1 Jan of the report year AND not departed before 1 Jan** — regardless of which year the departure happened. Departed rows with no `date_harvested` are treated as already gone.

Fixed in the same pass:
- **31 Dec boundary**: the In/Out/Destroyed columns string-compared datetimes against a plain `YYYY-12-31` bound, silently dropping anything timestamped on 31 December after midnight. All comparisons now use `DATE()` with an exclusive 1 Jan upper bound (plant *and* flower reports).
- **Harvested - Drying** from an earlier year now consistently counts as active stock in the opening balance, matching how the End column has treated drying plants since 0.14.

## Verification

- Calculations extracted to `annual_stocktake_lib.php` (shared by both endpoints) with a new regression suite `tests/test_annual_stocktake.php` (14 assertions: multi-year-old departures, previous-year departures, Dec-31 boundaries, drying-as-stock, sent/destroyed during the year, flower ledger balances) — wired into `tests/run_ci.sh`.
- **Replayed a real production backup** through the fixed calculation: long-departed plants disappear from the report, and the report-year End total now reconciles **exactly** with live stock (Growing + Drying counts). Year-over-year continuity holds: end(N) = start(N+1).
- Full CI suite: ALL CHECKS PASSED.

Version bumped to 0.16.1 (config.yaml, nav.php, header.php asset version, CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)