### PR TITLE
Release 0.16.1.1: Fix mobile hamburger icon stuck in top-left of its tap target

### DIFF
--- a/grace_addon/CHANGELOG.md
+++ b/grace_addon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.16.1.1] - 2026-06-12
+### Fixed
+- **Mobile hamburger icon**: the icon could render in the top-left corner of its tap target (visibly misaligned from the highlighted outline when tapped) in some mobile WebViews, e.g. the Home Assistant companion app. The bars are now pinned to the exact centre of the tap target with absolute offsets instead of flex centring, which those WebViews failed to apply.
+
 ## [0.16.1] - 2026-06-12
 ### Fixed
 - **Annual Stocktake opening balance**: plants that left stock more than one year before the report year (destroyed / sent / legacy-harvested) kept appearing in the Start Amount and End columns forever. The old query only subtracted departures dated within the *immediately previous* year, so e.g. a plant destroyed in 2024 still showed as stock-on-hand in the 2026 report. The opening balance is now "created before 1 Jan and not departed before 1 Jan", regardless of which year the departure happened. The report's End total now reconciles exactly with live stock (Growing + Drying).

--- a/grace_addon/config.yaml
+++ b/grace_addon/config.yaml
@@ -1,7 +1,7 @@
 name: "GRACe Portal"
 description: "Growers Regulatory Assistance & Compliance engine"
 url: "https://www.chilldivision.co.nz"
-version: "0.16.1"
+version: "0.16.1.1"
 slug: "grace_addon"
 panel_icon: mdi:cannabis
 init: false

--- a/grace_addon/files/general/www/public/css/growcart.css
+++ b/grace_addon/files/general/www/public/css/growcart.css
@@ -281,9 +281,8 @@ header.app-header {
 
 @media (max-width: 768px) {
   .nav-toggle-label {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    display: block;
+    position: relative;
     flex-shrink: 0;
     width: 2.75rem;
     height: 2.75rem;
@@ -296,13 +295,18 @@ header.app-header {
     background: var(--g-accent-soft);
   }
 
-  /* The three bars are anchored to .hamburger itself (position: relative),
-     so they never depend on the label/header for positioning */
+  /* The middle bar is pinned to the exact centre of the label with
+     absolute 50% offsets + negative margins (half its 22x2 size), and the
+     outer bars hang off it. No flex/grid centring involved — some mobile
+     WebViews (e.g. the HA companion app) failed to centre the flex child,
+     leaving the icon stuck in the label's top-left corner. */
   .hamburger {
-    position: relative;
-    display: block;
+    position: absolute;
+    top: 50%;
+    left: 50%;
     width: 22px;
     height: 2px;
+    margin: -1px 0 0 -11px;
     border-radius: 2px;
     background: currentColor;
     transition: background 0.25s ease;

--- a/grace_addon/files/general/www/public/header.php
+++ b/grace_addon/files/general/www/public/header.php
@@ -7,7 +7,7 @@
  *   $useJquery  - set true on pages that use the jQuery document manager
  */
 if (!defined('GRACE_ASSET_VERSION')) {
-    define('GRACE_ASSET_VERSION', '0.16.1');
+    define('GRACE_ASSET_VERSION', '0.16.1.1');
 }
 $pageTitle = $pageTitle ?? 'GRACe';
 ?>

--- a/grace_addon/files/general/www/public/nav.php
+++ b/grace_addon/files/general/www/public/nav.php
@@ -27,7 +27,7 @@ $navSections = [
                 </span>
                 <span class="nav-brand-text">
                     <strong>GRACe</strong>
-                    <span class="nav-brand-sub">by Chill Division <small>v0.16.1</small></span>
+                    <span class="nav-brand-sub">by Chill Division <small>v0.16.1.1</small></span>
                 </span>
             </a>
             <input type="checkbox" id="nav-toggle" class="nav-toggle">


### PR DESCRIPTION
Follow-up to #9 — this fix was pushed to that branch just after the squash-merge, so it never landed in 0.16.1.

## The bug
On some mobile WebViews — including the Home Assistant companion app — the hamburger/close icon rendered in the **top-left corner of its tap target**, visibly misaligned from the highlighted outline when tapped. Those WebViews did not apply the flex centring (`align-items`/`justify-content`) used to position the icon inside the toggle label, while desktop browsers did — which is why it kept passing desktop checks.

## The fix
Stop relying on flex entirely: the middle bar is pinned to the exact centre of the tap target with `position: absolute; top: 50%; left: 50%` plus negative margins of half its own size, and the outer bars hang off it. This behaves identically in every rendering engine. Verified the icon centre and tap-target centre are pixel-identical in both the closed (menu) and open (close) states.

Version bumped to 0.16.1.1 (config.yaml, nav.php, header.php asset version, CHANGELOG). Full CI suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)