### PR TITLE
Release 0.17.1: Open report emails in a new tab so webmail works under HA ingress

### DIFF
--- a/grace_addon/CHANGELOG.md
+++ b/grace_addon/CHANGELOG.md
@@ -1,5 +1,5 @@
-## [0.17.0] - 2026-06-13
-One big update — everything from 0.15 through 0.17.0 rolled together.
+## [0.17.1] - 2026-06-13
+One big update — everything from 0.15 through 0.17.1 rolled together.
 
 ### Features
 - **Fresh new look**: GRACe has been redesigned from top to bottom — a new Dashboard home page, tap-friendly menus and cards, dark & light themes, and a layout that works great on phones, tablets, and PCs.
@@ -23,6 +23,7 @@ One big update — everything from 0.15 through 0.17.0 rolled together.
 - Activity recorded on 31 December was missed by the annual report.
 - Manifests between two external companies recorded the wrong sender.
 - Refreshing the manifest result page could create a duplicate.
+- "Draft this in an email" now opens in a new tab, so webmail (like Gmail) works from inside the Home Assistant app.
 
 ### Under the hood
 - Removed old unused login code and bundled demo files; added a developer guide (`DEVELOPMENT.md`), a demo-data seeder, and more automated tests.

--- a/grace_addon/config.yaml
+++ b/grace_addon/config.yaml
@@ -1,7 +1,7 @@
 name: "GRACe Portal"
 description: "Growers Regulatory Assistance & Compliance engine"
 url: "https://www.chilldivision.co.nz"
-version: "0.17.0"
+version: "0.17.1"
 slug: "grace_addon"
 panel_icon: mdi:cannabis
 init: false

--- a/grace_addon/files/general/www/public/header.php
+++ b/grace_addon/files/general/www/public/header.php
@@ -7,7 +7,7 @@
  *   $useJquery  - set true on pages that use the jQuery document manager
  */
 if (!defined('GRACE_ASSET_VERSION')) {
-    define('GRACE_ASSET_VERSION', '0.17.0');
+    define('GRACE_ASSET_VERSION', '0.17.1');
 }
 $pageTitle = $pageTitle ?? 'GRACe';
 ?>

--- a/grace_addon/files/general/www/public/js/report_email.js
+++ b/grace_addon/files/general/www/public/js/report_email.js
@@ -32,9 +32,23 @@ function draftReportEmail(options) {
     const { subject, body, reminderType, reminderPeriod } = options;
 
     const openMailto = (mailBody) => {
-        window.location.href = 'mailto:' + GRACE_AGENCY_EMAIL
+        const url = 'mailto:' + GRACE_AGENCY_EMAIL
             + '?subject=' + encodeURIComponent(subject)
             + '&body=' + encodeURIComponent(mailBody);
+
+        // GRACe usually runs inside Home Assistant's ingress iframe.
+        // Navigating the iframe itself to a mailto: breaks when the
+        // browser's mail handler is webmail (e.g. Chrome rewrites it to a
+        // mail.google.com compose URL, and Gmail refuses to load inside a
+        // frame). Opening in a new browsing context works in both worlds:
+        // webmail handlers get their own tab, native mail apps just open.
+        const link = document.createElement('a');
+        link.href = url;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
     };
 
     if (body.length > GRACE_MAILTO_BODY_LIMIT && navigator.clipboard && navigator.clipboard.writeText) {

--- a/grace_addon/files/general/www/public/nav.php
+++ b/grace_addon/files/general/www/public/nav.php
@@ -27,7 +27,7 @@ $navSections = [
                 </span>
                 <span class="nav-brand-text">
                     <strong>GRACe</strong>
-                    <span class="nav-brand-sub">by Chill Division <small>v0.17.0</small></span>
+                    <span class="nav-brand-sub">by Chill Division <small>v0.17.1</small></span>
                 </span>
             </a>
             <input type="checkbox" id="nav-toggle" class="nav-toggle">


### PR DESCRIPTION
## The bug

"Draft this in an email" set `window.location.href` to the `mailto:` link — which navigates **the Home Assistant ingress iframe itself**. For users whose browser handles `mailto:` with webmail (e.g. Chrome + Gmail), the browser rewrites the mailto into a `https://mail.google.com/...` compose URL and tries to load Gmail *inside the GRACe frame*. Gmail sends `X-Frame-Options: sameorigin`, so the frame shows **"mail.google.com refused to connect"** instead of an email draft.

## The fix

The mailto is now opened via a programmatic anchor click with `target="_blank" rel="noopener noreferrer"`:
- **Webmail handlers** (Gmail etc.) get their own tab with the compose window pre-filled — exactly the intended experience.
- **Native mail apps** open just as before.
- The GRACe iframe itself never navigates, so nothing breaks under ingress.

It happens inside the click handler (a user gesture), so popup blockers don't interfere. The clipboard fallback for oversized reports is unchanged.

## Verification

Confirmed in-browser that clicking the button fires exactly one `_blank` anchor click with the correct pre-filled mailto URL, the page itself does not navigate, and the toast still appears. Full CI suite passes.

Version bumped to 0.17.1; the consolidated changelog entry now covers 0.15 → 0.17.1 with a one-line fix note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
