### PR TITLE
Release 0.17.2: Remove Recalls section, reorder Administration, drop em-dashes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,12 +1,12 @@
-# GRACe Portal — Local Development Guide
+# GRACe Portal: Local Development Guide
 
 How to run the portal on your own machine, fill it with demo data, and check
-your changes before committing — no Home Assistant install required.
+your changes before committing, no Home Assistant install required.
 
 ## Prerequisites
 
 - PHP 8.1+ CLI with the SQLite extension
-  (`sudo apt install php-cli php-sqlite3` on Debian/Ubuntu — WSL works fine)
+  (`sudo apt install php-cli php-sqlite3` on Debian/Ubuntu, WSL works fine)
 - The app **hard-codes** its persistent paths (see the warning in
   [README.md](README.md)), so you need a local `/data` directory:
 
@@ -20,7 +20,7 @@ sudo chown -R "$(whoami)" /data
 
 ## Spin up a dev server
 
-PHP's built-in server is all you need — the addon's nginx/php-fpm stack is
+PHP's built-in server is all you need, the addon's nginx/php-fpm stack is
 only for production packaging:
 
 ```bash
@@ -47,7 +47,7 @@ Tips:
 
 To explore the UI with realistic content (plants in every status, flower
 ledger entries this month and last, companies, and downloadable demo
-documents including a license that's about to expire — which exercises the
+documents including a license that's about to expire, which exercises the
 red banner and the dashboard warning):
 
 ```bash
@@ -73,7 +73,7 @@ can only see them at the right time of month. Two demo aids:
 
 ```bash
 # What would the dashboard show on any given day (or range)? Runs against
-# your dev database — perfect for screen recordings:
+# your dev database, perfect for screen recordings:
 php tests/demo_report_reminders.php 2027-01-01 2027-01-10
 
 # Or render the real dashboard as if it were another day:
@@ -119,15 +119,15 @@ CSS/JS.
   HA server, so "device is offline" is not a scenario we design for. The
   reason Pico CSS and jQuery are vendored locally (`css/vendor/`,
   `js/vendor/`) is that the *HA server itself* may be air-gapped from the
-  internet — that's an offline-server concern, not an offline-client one.
+  internet, that's an offline-server concern, not an offline-client one.
   Don't add a service worker, app-state caching, or background sync.
 - The portal is normally served through **Home Assistant ingress**, which
   mounts it under a deep path. Always use **relative URLs** for links,
-  assets, and fetch calls — never absolute paths starting with `/`.
+  assets, and fetch calls, never absolute paths starting with `/`.
 - Authentication is Home Assistant's job. There is intentionally no login
   system in the app (the old `auth.php`/`login.php` were removed in 0.15.1).
 - The ledger is intentionally **append-only**: no UI for editing or deleting
   historical plant/flower records should be added. Corrections happen via
   compensating entries.
-- Persistent-path rules (`/data/grace.db`, `/data/uploads/`) are absolute —
-  see the "CRITICAL DEVELOPER NOTES" section in [README.md](README.md).
+- Persistent-path rules (`/data/grace.db`, `/data/uploads/`) are absolute.
+  See the "CRITICAL DEVELOPER NOTES" section in [README.md](README.md).

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Files are stored in `/data/uploads`, which is a permanent storage volume in Home
 
 ## Local Testing
 
-See [DEVELOPMENT.md](DEVELOPMENT.md) for how to spin up a local dev server, seed demo data into the database, and preview UI changes before committing. It also contains important notes for AI assistants (e.g. no service worker / offline-first support is wanted — users always reach GRACe over the LAN via their Home Assistant server).
+See [DEVELOPMENT.md](DEVELOPMENT.md) for how to spin up a local dev server, seed demo data into the database, and preview UI changes before committing. It also contains important notes for AI assistants (e.g. no service worker / offline-first support is wanted, users always reach GRACe over the LAN via their Home Assistant server).
 
 This repository includes a manual CI testing suite for local development.
 

--- a/grace_addon/CHANGELOG.md
+++ b/grace_addon/CHANGELOG.md
@@ -1,17 +1,17 @@
-## [0.17.1] - 2026-06-13
-One big update — everything from 0.15 through 0.17.1 rolled together.
+## [0.17.2] - 2026-06-13
+One big update. Everything from 0.15 through 0.17.2 rolled together.
 
 ### Features
-- **Fresh new look**: GRACe has been redesigned from top to bottom — a new Dashboard home page, tap-friendly menus and cards, dark & light themes, and a layout that works great on phones, tablets, and PCs.
-- **Dashboard**: your grow at a glance — plants growing and drying, dried flower on hand, what went out this month, manifests awaiting paperwork, and license renewal reminders.
-- **Agency report reminders**: in the first week of each month, the Dashboard reminds you to send last month's materials-out report — but only if you actually sent materials out, so quiet months stay quiet. In January it also reminds you about the annual stocktake. Reminders can be dismissed and never pile up.
-- **One-tap report emails**: a "Draft this in an email" button on the monthly materials-out and annual stocktake reports opens a ready-to-send email to the Medicinal Cannabis Agency — subject line, your company details, and the full report already filled in. No more copy/paste.
+- **Fresh new look**: GRACe has been redesigned from top to bottom, with a new Dashboard home page, tap-friendly menus and cards, dark & light themes, and a layout that works great on phones, tablets, and PCs.
+- **Dashboard**: your grow at a glance, showing plants growing and drying, dried flower on hand, what went out this month, manifests awaiting paperwork, and license renewal reminders.
+- **Agency report reminders**: in the first week of each month, the Dashboard reminds you to send last month's materials-out report, but only if you actually sent materials out, so quiet months stay quiet. In January it also reminds you about the annual stocktake. Reminders can be dismissed and never pile up.
+- **One-tap report emails**: a "Draft this in an email" button on the monthly materials-out and annual stocktake reports opens a ready-to-send email to the Medicinal Cannabis Agency, with the subject line, your company details, and the full report already filled in. No more copy/paste.
 - **Smarter shipping manifests**: a manifest now stays "In Progress" until the signed Chain of Custody is attached, shipped flower is automatically deducted from your inventory, and every exchange has its own summary page with the PDF and CoC.
-- **Annual report fix**: plants destroyed or sent in past years no longer show up as stock in later years' annual stocktake — the report's totals now match your real live stock.
+- **Annual report fix**: plants destroyed or sent in past years no longer show up as stock in later years' annual stocktake, so the report's totals now match your real live stock.
 - **Install like an app**: pin GRACe to your phone's home screen.
 
 ### Improvements
-- A double-check screen before harvesting, destroying, or sending plants — because the ledger can't be edited afterwards.
+- A double-check screen before harvesting, destroying, or sending plants, because the ledger can't be edited afterwards.
 - Friendlier in-app messages instead of browser pop-ups.
 - "Download backup" saves your whole ledger as a single file.
 - Works on Home Assistant boxes with no internet connection.
@@ -24,6 +24,7 @@ One big update — everything from 0.15 through 0.17.1 rolled together.
 - Manifests between two external companies recorded the wrong sender.
 - Refreshing the manifest result page could create a duplicate.
 - "Draft this in an email" now opens in a new tab, so webmail (like Gmail) works from inside the Home Assistant app.
+- Tidied up the menus: removed the empty "Recalls" placeholder from Plant Tracking, and put Record Management at the top of the Administration page in a more sensible order.
 
 ### Under the hood
 - Removed old unused login code and bundled demo files; added a developer guide (`DEVELOPMENT.md`), a demo-data seeder, and more automated tests.

--- a/grace_addon/DOCS.md
+++ b/grace_addon/DOCS.md
@@ -38,10 +38,10 @@ When product physically leaves your site, generate a manifest under Tracking →
 
 Two things happen automatically at that moment:
 
-- If you're sending flower to an external company, the shipped weight is deducted from your dried-flower inventory straight away — you don't need to make a separate "Record dry weight change" entry, and it shows up in your monthly materials-out report like any other send.
+- If you're sending flower to an external company, the shipped weight is deducted from your dried-flower inventory straight away. You don't need to make a separate "Record dry weight change" entry, and it shows up in your monthly materials-out report like any other send.
 - The manifest is recorded as "In Progress". It stays that way while the product is in transit.
 
-Once the shipment has been received and you have the signed Chain of Custody back (a photo of the signed paperwork is fine, or a scanned PDF), go to Tracking → "Complete Manifest". You'll see every manifest still awaiting completion with its date, destination and what was shipped — choose the right one, attach the Chain of Custody, and complete it. GRACe will not let a manifest be closed off without a Chain of Custody attached.
+Once the shipment has been received and you have the signed Chain of Custody back (a photo of the signed paperwork is fine, or a scanned PDF), go to Tracking → "Complete Manifest". You'll see every manifest still awaiting completion with its date, destination and what was shipped, so you can choose the right one, attach the Chain of Custody, and complete it. GRACe will not let a manifest be closed off without a Chain of Custody attached.
 
 You can still upload standalone Chain of Custody paperwork on the Administration → "Chain of Custody Documents" page like before, and anything uploaded there can be attached to a manifest later from the Complete Manifest page. Each exchange also has a summary page (linked from both pages) showing the source, destination, shipment details, inventory deduction and the attached paperwork.
 

--- a/grace_addon/config.yaml
+++ b/grace_addon/config.yaml
@@ -1,7 +1,7 @@
 name: "GRACe Portal"
 description: "Growers Regulatory Assistance & Compliance engine"
 url: "https://www.chilldivision.co.nz"
-version: "0.17.1"
+version: "0.17.2"
 slug: "grace_addon"
 panel_icon: mdi:cannabis
 init: false

--- a/grace_addon/files/general/www/public/administration.php
+++ b/grace_addon/files/general/www/public/administration.php
@@ -10,6 +10,47 @@ require 'header.php';
         </hgroup>
 
         <section class="hub-section">
+            <h2>Record Management</h2>
+            <div class="card-grid">
+                <a class="nav-card" href="chain_of_custody_documents.php">
+                    <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 17H7A5 5 0 0 1 7 7h2"/><path d="M15 7h2a5 5 0 1 1 0 10h-2"/><path d="M8 12h8"/></svg></span>
+                    <span class="nav-card-body">
+                        <strong>Chain of Custody Documents</strong>
+                        <small>Store signed CoC paperwork for every transfer</small>
+                    </span>
+                </a>
+                <a class="nav-card" href="company_licenses.php">
+                    <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="m9 15 2 2 4-4"/></svg></span>
+                    <span class="nav-card-body">
+                        <strong>Company Licenses</strong>
+                        <small>Upload licenses with expiry tracking and renewal alerts</small>
+                    </span>
+                </a>
+                <a class="nav-card" href="sops.php">
+                    <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg></span>
+                    <span class="nav-card-body">
+                        <strong>Manage SOPs</strong>
+                        <small>Upload and track your Standard Operating Procedures</small>
+                    </span>
+                </a>
+                <a class="nav-card" href="police_vet_check_records.php">
+                    <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1 1 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1Z"/><path d="m9 12 2 2 4-4"/></svg></span>
+                    <span class="nav-card-body">
+                        <strong>Police Vet Check Records</strong>
+                        <small>Store vetting records for staff and key personnel</small>
+                    </span>
+                </a>
+                <a class="nav-card" href="offtake_agreements.php">
+                    <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M16 13H8"/><path d="M16 17H8"/><path d="M10 9H8"/></svg></span>
+                    <span class="nav-card-body">
+                        <strong>Offtake Agreements</strong>
+                        <small>Keep signed buyer agreements on file</small>
+                    </span>
+                </a>
+            </div>
+        </section>
+
+        <section class="hub-section">
             <h2>Contact Management</h2>
             <div class="card-grid">
                 <a class="nav-card" href="add_verified_company.php">
@@ -30,47 +71,6 @@ require 'header.php';
                     <span class="nav-card-body">
                         <strong>Add New Genetics</strong>
                         <small>Any genetics you'll have as either plants or flower</small>
-                    </span>
-                </a>
-            </div>
-        </section>
-
-        <section class="hub-section">
-            <h2>Record Management</h2>
-            <div class="card-grid">
-                <a class="nav-card" href="police_vet_check_records.php">
-                    <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1 1 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1Z"/><path d="m9 12 2 2 4-4"/></svg></span>
-                    <span class="nav-card-body">
-                        <strong>Police Vet Check Records</strong>
-                        <small>Store vetting records for staff and key personnel</small>
-                    </span>
-                </a>
-                <a class="nav-card" href="sops.php">
-                    <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg></span>
-                    <span class="nav-card-body">
-                        <strong>Manage SOPs</strong>
-                        <small>Upload and track your Standard Operating Procedures</small>
-                    </span>
-                </a>
-                <a class="nav-card" href="offtake_agreements.php">
-                    <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M16 13H8"/><path d="M16 17H8"/><path d="M10 9H8"/></svg></span>
-                    <span class="nav-card-body">
-                        <strong>Offtake Agreements</strong>
-                        <small>Keep signed buyer agreements on file</small>
-                    </span>
-                </a>
-                <a class="nav-card" href="company_licenses.php">
-                    <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="m9 15 2 2 4-4"/></svg></span>
-                    <span class="nav-card-body">
-                        <strong>Company Licenses</strong>
-                        <small>Upload licenses with expiry tracking and renewal alerts</small>
-                    </span>
-                </a>
-                <a class="nav-card" href="chain_of_custody_documents.php">
-                    <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 17H7A5 5 0 0 1 7 7h2"/><path d="M15 7h2a5 5 0 1 1 0 10h-2"/><path d="M8 12h8"/></svg></span>
-                    <span class="nav-card-body">
-                        <strong>Chain of Custody Documents</strong>
-                        <small>Store signed CoC paperwork for every transfer</small>
                     </span>
                 </a>
             </div>

--- a/grace_addon/files/general/www/public/annual_stocktake_lib.php
+++ b/grace_addon/files/general/www/public/annual_stocktake_lib.php
@@ -6,7 +6,7 @@
  *
  * Date handling: date_created / date_harvested / transaction_date are stored
  * as 'YYYY-MM-DD HH:MM:SS' datetimes, so all comparisons wrap them in DATE()
- * and compare against exclusive year boundaries — a plain string BETWEEN
+ * and compare against exclusive year boundaries, a plain string BETWEEN
  * '...-01-01' AND '...-12-31' silently drops anything timestamped on
  * 31 December after midnight.
  */
@@ -19,7 +19,7 @@ const GRACE_PLANT_DEPARTED_STATUSES = ['Sent', 'Harvested', 'Harvested - Destroy
  * Per-genetics plant stocktake for one calendar year.
  *
  * Start amount = plants created before 1 Jan that had not left stock before
- * 1 Jan — regardless of WHICH earlier year they left in. (Pre-0.16.1 this
+ * 1 Jan, regardless of WHICH earlier year they left in. (Pre-0.16.1 this
  * only subtracted departures dated in the immediately-previous year, so a
  * plant destroyed two or more years ago kept appearing in the opening
  * balance forever.)

--- a/grace_addon/files/general/www/public/chain_of_custody_documents.php
+++ b/grace_addon/files/general/www/public/chain_of_custody_documents.php
@@ -24,7 +24,7 @@ require 'header.php';
                 <button type="submit">Upload</button>
             </form>
             <p><small>Uploads here are stored as standalone documents. To close out a manifest in transit,
-            attach its CoC on the <a href="complete_manifest.php">Complete Manifest</a> page — documents
+            attach its CoC on the <a href="complete_manifest.php">Complete Manifest</a> page. Documents
             uploaded here can be selected there too.</small></p>
         </article>
 

--- a/grace_addon/files/general/www/public/company_licenses.php
+++ b/grace_addon/files/general/www/public/company_licenses.php
@@ -7,7 +7,7 @@ require 'header.php';
     <main class="container">
         <hgroup class="page-header">
             <h1>Company Licenses</h1>
-            <p>Upload licenses with an expiry date — GRACe alerts you before they lapse.</p>
+            <p>Upload licenses with an expiry date so GRACe can alert you before they lapse.</p>
         </hgroup>
 
         <article class="form-card">

--- a/grace_addon/files/general/www/public/complete_manifest.php
+++ b/grace_addon/files/general/www/public/complete_manifest.php
@@ -98,7 +98,7 @@ require 'header.php';
                 <?php if (!empty($availableCocDocs)): ?>
                 <label for="existingDocId">…or attach one already uploaded on the Chain of Custody page:</label>
                 <select id="existingDocId" name="existing_document_id">
-                    <option value="">— Select an uploaded document —</option>
+                    <option value="">Select an uploaded document</option>
                     <?php foreach ($availableCocDocs as $doc): ?>
                     <option value="<?php echo (int) $doc['id']; ?>">
                         <?php echo htmlspecialchars($doc['original_filename'] . ' (uploaded ' . $doc['upload_date'] . ')'); ?>

--- a/grace_addon/files/general/www/public/css/growcart.css
+++ b/grace_addon/files/general/www/public/css/growcart.css
@@ -1,5 +1,5 @@
 /* ==========================================================================
-   GRACe design system — layered on top of Pico CSS v2
+   GRACe design system, layered on top of Pico CSS v2
    Custom component classes are prefixed where practical; --g-* tokens hold
    the palette so dark/light themes stay in sync.
    ========================================================================== */
@@ -297,7 +297,7 @@ header.app-header {
 
   /* The middle bar is pinned to the exact centre of the label with
      absolute 50% offsets + negative margins (half its 22x2 size), and the
-     outer bars hang off it. No flex/grid centring involved — some mobile
+     outer bars hang off it. No flex/grid centring involved, some mobile
      WebViews (e.g. the HA companion app) failed to centre the flex child,
      leaving the icon stuck in the label's top-left corner. */
   .hamburger {

--- a/grace_addon/files/general/www/public/dashboard.php
+++ b/grace_addon/files/general/www/public/dashboard.php
@@ -28,7 +28,7 @@ try {
     $stats['drying'] = (int) $pdo->query("SELECT COUNT(*) FROM Plants WHERE status = 'Harvested - Drying'")->fetchColumn();
     $stats['flowerOnHand'] = (float) $pdo->query("SELECT COALESCE(SUM(weight), 0) FROM Flower")->fetchColumn();
 
-    // Materials out this month — same definitions as the monthly Agency report
+    // Materials out this month, same definitions as the monthly Agency report
     $startDate = date('Y-m-01');
     $endDate = date('Y-m-t 23:59:59');
 
@@ -55,8 +55,8 @@ try {
     $stmt->execute([$horizon]);
     $expiringLicenses = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-    // Agency report reminders (windowed — see report_reminders_lib.php).
-    // ?demo_date=YYYY-MM-DD pretends it's another day — read-only, used for
+    // Agency report reminders (windowed, see report_reminders_lib.php).
+    // ?demo_date=YYYY-MM-DD pretends it's another day, read-only, used for
     // demos/videos to show the banners outside their real windows.
     $demoDate = (isset($_GET['demo_date']) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $_GET['demo_date']))
         ? $_GET['demo_date'] : null;
@@ -204,7 +204,7 @@ require 'header.php';
                     .then(data => {
                         if (data.success) {
                             banner.remove();
-                            showToast('Reminder dismissed — it won\'t show again for this report.', 'info');
+                            showToast('Reminder dismissed. It won\'t show again for this report.', 'info');
                         } else {
                             showToast('Could not dismiss the reminder: ' + (data.message || 'unknown error'), 'error');
                         }

--- a/grace_addon/files/general/www/public/generate_shipping_manifest.php
+++ b/grace_addon/files/general/www/public/generate_shipping_manifest.php
@@ -37,8 +37,8 @@ require 'header.php';
         <article class="form-card">
             <p><strong>How this works:</strong> generating a manifest records it as <span class="badge badge--drying">In Progress</span>.
             If you are sending <strong>flower</strong> to an external company, the shipped weight is
-            <strong>automatically deducted from your dried-flower inventory</strong> the moment the manifest is generated —
-            no separate ledger entry is needed. The manifest stays In Progress until the signed Chain of Custody
+            <strong>automatically deducted from your dried-flower inventory</strong> the moment the manifest is generated,
+            so no separate ledger entry is needed. The manifest stays In Progress until the signed Chain of Custody
             (photo or PDF) is attached on the <a href="complete_manifest.php">Complete Manifest</a> page.</p>
         </article>
 
@@ -178,7 +178,7 @@ require 'header.php';
             const grams = flowerStock[geneticsSelect.value] || 0;
             const name = geneticsSelect.options[geneticsSelect.selectedIndex].text.trim();
             stockHint.textContent = `Recorded dried-flower stock for ${name}: ${grams} g` +
-                (deductionApplies ? ' — the manifest weight will be deducted from this automatically.' : '');
+                (deductionApplies ? '. The manifest weight will be deducted from this automatically.' : '');
         };
 
         [productType, geneticsSelect].forEach(el => el.addEventListener('change', updateStockHint));

--- a/grace_addon/files/general/www/public/handle_complete_manifest.php
+++ b/grace_addon/files/general/www/public/handle_complete_manifest.php
@@ -66,7 +66,7 @@ if ($hasUpload) {
     $stmt->execute([$file['name'], $uniqueName, date('Y-m-d H:i:s')]);
     $cocDocumentId = (int) $pdo->lastInsertId();
 } else {
-    // Attach an existing manually-uploaded CoC document — it must exist and
+    // Attach an existing manually-uploaded CoC document, it must exist and
     // not already be covering another manifest
     $stmt = $pdo->prepare("SELECT id FROM Documents
                            WHERE id = ? AND category = 'coc'
@@ -85,7 +85,7 @@ $stmt = $pdo->prepare("UPDATE ShippingManifests
 $stmt->execute([$cocDocumentId, date('Y-m-d H:i:s'), $manifestId]);
 
 if ($stmt->rowCount() === 0) {
-    respond(false, 'Manifest could not be completed — it may have been completed already.');
+    respond(false, 'Manifest could not be completed. It may have been completed already.');
 }
 
 respond(true, 'Manifest completed', ['manifest_id' => $manifestId]);

--- a/grace_addon/files/general/www/public/harvest_plants.php
+++ b/grace_addon/files/general/www/public/harvest_plants.php
@@ -132,7 +132,7 @@ require 'header.php';
                 return;
             }
 
-            // Build a per-genetics summary of what's about to happen — the ledger
+            // Build a per-genetics summary of what's about to happen, the ledger
             // can't be edited afterwards, so make the user review it first
             const countsByGenetics = {};
             selectedCheckboxes.forEach(checkbox => {

--- a/grace_addon/files/general/www/public/header.php
+++ b/grace_addon/files/general/www/public/header.php
@@ -7,7 +7,7 @@
  *   $useJquery  - set true on pages that use the jQuery document manager
  */
 if (!defined('GRACE_ASSET_VERSION')) {
-    define('GRACE_ASSET_VERSION', '0.17.1');
+    define('GRACE_ASSET_VERSION', '0.17.2');
 }
 $pageTitle = $pageTitle ?? 'GRACe';
 ?>

--- a/grace_addon/files/general/www/public/init_db.php
+++ b/grace_addon/files/general/www/public/init_db.php
@@ -128,7 +128,7 @@ function initializeDatabase($dbPath = '/data/grace.db') {
                 upload_date DATETIME DEFAULT CURRENT_TIMESTAMP
             );",
 
-            // ReportReminders — tracks Agency report reminders the user has
+            // ReportReminders, tracks Agency report reminders the user has
             // dismissed or drafted (added in 0.17.0). period is '2026-05'
             // for monthly reports or '2025' for the annual stocktake.
             "CREATE TABLE IF NOT EXISTS ReportReminders (

--- a/grace_addon/files/general/www/public/js/growcart.js
+++ b/grace_addon/files/general/www/public/js/growcart.js
@@ -23,7 +23,7 @@
         button.innerHTML = currentTheme() === 'light' ? moon : sun;
     }
 
-    // Make sure the mobile menu is closed after back/forward navigation —
+    // Make sure the mobile menu is closed after back/forward navigation
     // the checkbox state can otherwise be restored as "open" by the bfcache
     window.addEventListener('pageshow', () => {
         const navToggle = document.getElementById('nav-toggle');
@@ -42,7 +42,7 @@
             html.setAttribute('data-theme', next);
             try {
                 localStorage.setItem('grace-theme', next);
-            } catch (err) { /* private browsing etc. — toggle still works for this page */ }
+            } catch (err) { /* private browsing etc., toggle still works for this page */ }
             renderIcon(switchTheme);
         });
     });
@@ -84,13 +84,13 @@ function showToast(message, type = 'info', duration = 4500) {
 }
 
 /**
- * Queue a toast to be shown after the next page load — use before
+ * Queue a toast to be shown after the next page load, use before
  * location.reload() / navigation so the message isn't lost.
  */
 function flashToast(message, type = 'success') {
     try {
         sessionStorage.setItem('grace-flash', JSON.stringify({ message: message, type: type }));
-    } catch (e) { /* sessionStorage unavailable — message is lost, not fatal */ }
+    } catch (e) { /* sessionStorage unavailable, message is lost, not fatal */ }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -125,7 +125,7 @@ function confirmAction(options) {
     const danger = !!opts.danger;
 
     if (typeof HTMLDialogElement === 'undefined') {
-        // Very old browser — fall back to the native dialog
+        // Very old browser, fall back to the native dialog
         return Promise.resolve(window.confirm(title + (message ? '\n\n' + message : '')));
     }
 

--- a/grace_addon/files/general/www/public/js/report_email.js
+++ b/grace_addon/files/general/www/public/js/report_email.js
@@ -16,7 +16,7 @@
 
 const GRACE_AGENCY_EMAIL = 'medicinal_cannabis@health.govt.nz';
 
-// Conservative limit for mailto body length — beyond this some mail clients
+// Conservative limit for mailto body length, beyond this some mail clients
 // silently cut the message off, so we switch to the clipboard instead
 const GRACE_MAILTO_BODY_LIMIT = 1800;
 
@@ -52,12 +52,12 @@ function draftReportEmail(options) {
     };
 
     if (body.length > GRACE_MAILTO_BODY_LIMIT && navigator.clipboard && navigator.clipboard.writeText) {
-        // Too long for a reliable mailto body — clipboard fallback
+        // Too long for a reliable mailto body, clipboard fallback
         navigator.clipboard.writeText(body).then(() => {
-            openMailto('(The report was too long to pre-fill — it has been copied to your clipboard. Paste it here.)');
-            showToast('Report copied to your clipboard — paste it into the email body.', 'info', 8000);
+            openMailto('(The report was too long to pre-fill, so it has been copied to your clipboard. Paste it here.)');
+            showToast('Report copied to your clipboard. Paste it into the email body.', 'info', 8000);
         }).catch(() => {
-            // Clipboard unavailable — best effort with the full body anyway
+            // Clipboard unavailable, best effort with the full body anyway
             openMailto(body);
             showToast('Heads up: long reports can be cut off by some mail apps. Double-check the email body.', 'info', 8000);
         });
@@ -66,7 +66,7 @@ function draftReportEmail(options) {
         showToast('Email draft opened in your mail app.', 'success');
     }
 
-    // Mark the dashboard reminder as drafted (fire and forget — drafting
+    // Mark the dashboard reminder as drafted (fire and forget, drafting
     // the email is the action we wanted, even if this recording fails)
     if (reminderType && reminderPeriod) {
         const params = new URLSearchParams({

--- a/grace_addon/files/general/www/public/last_months_flower_transactions.php
+++ b/grace_addon/files/general/www/public/last_months_flower_transactions.php
@@ -100,7 +100,7 @@ require 'header.php';
 
                 const flowerLines = reportTableLines(
                     document.getElementById('flowerTransactionsTable'),
-                    // cells: genetics, weight, date, company — skip the bold totals row
+                    // cells: genetics, weight, date, company, skip the bold totals row
                     cells => cells[0] === 'Total' ? null : `- ${cells[0]}: ${cells[1]} g on ${cells[2]} to ${cells[3]}`
                 ).filter(Boolean);
 

--- a/grace_addon/files/general/www/public/list_all_genetics.php
+++ b/grace_addon/files/general/www/public/list_all_genetics.php
@@ -6,7 +6,7 @@ require 'header.php';
     <main class="container">
         <hgroup class="page-header">
             <h1>List All Genetics</h1>
-            <p>Current and historical plants — live, harvested, destroyed, and sent.</p>
+            <p>Current and historical plants: live, harvested, destroyed, and sent.</p>
         </hgroup>
 
         <div class="toolbar">

--- a/grace_addon/files/general/www/public/manifest_summary.php
+++ b/grace_addon/files/general/www/public/manifest_summary.php
@@ -37,7 +37,7 @@ require 'header.php';
                                 <?php if ($manifest['flower_transaction_id']): ?>
                                     <?php echo htmlspecialchars(abs((float) $manifest['deducted_weight']) . ' g deducted from the dried-flower ledger on ' . $manifest['deduction_date']); ?>
                                 <?php elseif ($manifest['product_type'] === 'flower'): ?>
-                                    None — this shipment was not sent from our inventory.
+                                    None. This shipment was not sent from our inventory.
                                 <?php else: ?>
                                     n/a (plants are processed out via Harvest / Destroy / Send)
                                 <?php endif; ?>
@@ -55,14 +55,14 @@ require 'header.php';
                                 <?php endif; ?>
                             </td>
                         </tr>
-                        <tr><td><strong>Completed</strong></td><td><?php echo $manifest['date_completed'] ? htmlspecialchars($manifest['date_completed']) : '—'; ?></td></tr>
+                        <tr><td><strong>Completed</strong></td><td><?php echo $manifest['date_completed'] ? htmlspecialchars($manifest['date_completed']) : 'Not yet'; ?></td></tr>
                         <tr>
                             <td><strong>Manifest PDF</strong></td>
                             <td>
                                 <?php if ($manifest['manifest_file']): ?>
                                     <a href="download.php?category=manifests&file=<?php echo urlencode($manifest['manifest_file']); ?>" download>Download manifest PDF</a>
                                 <?php else: ?>
-                                    —
+                                    None
                                 <?php endif; ?>
                             </td>
                         </tr>
@@ -85,13 +85,13 @@ require 'header.php';
             document.addEventListener('DOMContentLoaded', () => {
                 if (urlParams.get('created')) {
                     <?php if ($manifest['flower_transaction_id']): ?>
-                    showToast('Manifest #<?php echo (int) $manifest['id']; ?> created — <?php echo abs((float) $manifest['deducted_weight']); ?> g deducted from dried-flower inventory. Attach the Chain of Custody to complete it.', 'success', 8000);
+                    showToast('Manifest #<?php echo (int) $manifest['id']; ?> created. <?php echo abs((float) $manifest['deducted_weight']); ?> g deducted from dried-flower inventory. Attach the Chain of Custody to complete it.', 'success', 8000);
                     <?php else: ?>
                     showToast('Manifest #<?php echo (int) $manifest['id']; ?> created as In Progress. Attach the Chain of Custody to complete it.', 'success', 8000);
                     <?php endif; ?>
                 }
                 if (urlParams.get('completed')) {
-                    showToast('Manifest #<?php echo (int) $manifest['id']; ?> completed — Chain of Custody attached.', 'success');
+                    showToast('Manifest #<?php echo (int) $manifest['id']; ?> completed. Chain of Custody attached.', 'success');
                 }
             });
         </script>

--- a/grace_addon/files/general/www/public/nav.php
+++ b/grace_addon/files/general/www/public/nav.php
@@ -27,7 +27,7 @@ $navSections = [
                 </span>
                 <span class="nav-brand-text">
                     <strong>GRACe</strong>
-                    <span class="nav-brand-sub">by Chill Division <small>v0.17.1</small></span>
+                    <span class="nav-brand-sub">by Chill Division <small>v0.17.2</small></span>
                 </span>
             </a>
             <input type="checkbox" id="nav-toggle" class="nav-toggle">

--- a/grace_addon/files/general/www/public/process_shipping_manifest.php
+++ b/grace_addon/files/general/www/public/process_shipping_manifest.php
@@ -6,7 +6,7 @@ require_once 'init_db.php';
 $pdo = initializeDatabase();
 
 // Manifests are only ever created from the generate form (POST). A stray GET
-// (refresh, bookmark) just goes back to the form — nothing is written twice.
+// (refresh, bookmark) just goes back to the form, nothing is written twice.
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     header('Location: generate_shipping_manifest.php');
     exit();

--- a/grace_addon/files/general/www/public/report_reminders_lib.php
+++ b/grace_addon/files/general/www/public/report_reminders_lib.php
@@ -6,7 +6,7 @@
  * rule is that reminders are WINDOWS, not queues: we only ever evaluate the
  * current window (the first 7 days of this month for last month's materials
  * out, or any day in January for the annual stocktake). We never scan
- * history for "unreported" periods, so a user can see at most two banners —
+ * history for "unreported" periods, so a user can see at most two banners
  * and a fresh install is never flooded with reminders about the past.
  *
  * Dismissals/drafts are stored per period in the ReportReminders table, so
@@ -30,7 +30,7 @@ function getDueReportReminders(PDO $pdo, $today = null)
     $due = [];
 
     // Reminders only make sense once company details exist (set during first
-    // run) — the report email needs the company name and license number.
+    // run), the report email needs the company name and license number.
     $hasCompany = (int) $pdo->query("SELECT COUNT(*) FROM OwnCompany")->fetchColumn() > 0;
     if (!$hasCompany) {
         return $due;

--- a/grace_addon/files/general/www/public/show_database.php
+++ b/grace_addon/files/general/www/public/show_database.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'init_db.php';
 
-// Downloads the full ledger as a timestamped JSON file — useful for backups
+// Downloads the full ledger as a timestamped JSON file, useful for backups
 // and audits. Read-only; the SQLite file itself lives at /data/grace.db.
 try {
     $pdo = initializeDatabase();

--- a/grace_addon/files/general/www/public/tracking.php
+++ b/grace_addon/files/general/www/public/tracking.php
@@ -6,7 +6,7 @@ require 'header.php';
     <main class="container">
         <hgroup class="page-header">
             <h1>Plant Tracking</h1>
-            <p>Day-to-day plant and dried flower movements — every change in your ledger starts here.</p>
+            <p>Day-to-day plant and dried flower movements. Every change in your ledger starts here.</p>
         </hgroup>
 
         <section class="hub-section">
@@ -30,7 +30,7 @@ require 'header.php';
                     <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M20 4 8.12 15.88"/><path d="M14.47 14.48 20 20"/><path d="M8.12 8.12 12 12"/></svg></span>
                     <span class="nav-card-body">
                         <strong>Harvest / Destroy / Send plants</strong>
-                        <small>Process whole plants out of the grow — harvest for drying, destroy, or send externally</small>
+                        <small>Process whole plants out of the grow: harvest for drying, destroy, or send externally</small>
                     </span>
                 </a>
                 <a class="nav-card" href="record_dry_weight.php">
@@ -60,20 +60,6 @@ require 'header.php';
                         <small>Attach the signed Chain of Custody and close out a manifest in transit</small>
                     </span>
                 </a>
-            </div>
-        </section>
-
-        <section class="hub-section">
-            <h2>Recalls</h2>
-            <div class="card-grid">
-                <div class="nav-card is-disabled" aria-disabled="true">
-                    <span class="nav-card-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg></span>
-                    <span class="nav-card-body">
-                        <strong>Initiate Recall</strong>
-                        <small>Start a product recall and notify affected parties</small>
-                        <span class="badge-soon">Coming soon</span>
-                    </span>
-                </div>
             </div>
         </section>
 

--- a/tests/demo_report_reminders.php
+++ b/tests/demo_report_reminders.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * demo_report_reminders.php — show what the dashboard reminders would do on
+ * demo_report_reminders.php, show what the dashboard reminders would do on
  * any date, against your local dev database (/data/grace.db). Great for
  * demos and videos: walk through a month without touching the system clock.
  *

--- a/tests/seed_demo_data.php
+++ b/tests/seed_demo_data.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * seed_demo_data.php — populate a local dev database with realistic demo data.
+ * seed_demo_data.php, populate a local dev database with realistic demo data.
  *
  * Usage (from the repo root):
  *   php tests/seed_demo_data.php           # seeds an empty database
  *   php tests/seed_demo_data.php --force   # wipes /data/grace.db first, then seeds
  *
  * Requires the persistent dirs used by the app: /data and /data/uploads
- * (see DEVELOPMENT.md). Never run this against a real production database —
+ * (see DEVELOPMENT.md). Never run this against a real production database
  * it refuses to touch a DB that already has company info unless --force is given.
  */
 
@@ -161,7 +161,7 @@ foreach ($flowerRows as $f) {
     $stmt->execute([$f[0], $f[1], $f[2], $f[3], "-{$f[4]} days", $f[5]]);
 }
 
-// Outbound flower mid-last-month, whatever month it is right now — so the
+// Outbound flower mid-last-month, whatever month it is right now, so the
 // dashboard's monthly Agency report reminder always has something to show
 // during the first 7 days of the month (see DEVELOPMENT.md for demo tips)
 $pdo->exec("INSERT INTO Flower (genetics_id, weight, transaction_type, reason, transaction_date, company_id)

--- a/tests/test_annual_stocktake.php
+++ b/tests/test_annual_stocktake.php
@@ -24,7 +24,7 @@ function check($label, $actual, $expected)
     if ($actual === $expected) {
         echo "[PASS] $label\n";
     } else {
-        echo "[FAIL] $label — expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n";
+        echo "[FAIL] $label, expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n";
         $failures++;
     }
 }
@@ -34,7 +34,7 @@ $year = 2026;
 
 $pdo->exec("INSERT INTO Genetics (name) VALUES ('Alpha'), ('Bravo')");
 
-// Alpha (genetics_id 1) — plant scenarios
+// Alpha (genetics_id 1), plant scenarios
 $pdo->exec("INSERT INTO Plants (genetics_id, status, date_created, date_harvested) VALUES
     -- 1. THE BUG: destroyed two years before the report year -> must not be in 2026 at all
     (1, 'Destroyed',             '2024-03-01 10:00:00', '2024-10-20 02:26:58'),
@@ -55,7 +55,7 @@ $pdo->exec("INSERT INTO Plants (genetics_id, status, date_created, date_harveste
     -- 9. legacy 'Harvested' before the report year -> left stock, not in start
     (1, 'Harvested',             '2023-01-01 10:00:00', '2023-09-09 10:00:00')");
 
-// Bravo (genetics_id 2) — entirely departed before the report year (the 'Medicine Girl' case)
+// Bravo (genetics_id 2), entirely departed before the report year (the 'Medicine Girl' case)
 $pdo->exec("INSERT INTO Plants (genetics_id, status, date_created, date_harvested) VALUES
     (2, 'Destroyed', '2023-02-02 10:00:00', '2024-01-15 10:00:00'),
     (2, 'Sent',      '2023-02-02 10:00:00', '2024-02-20 10:00:00')");

--- a/tests/test_report_reminders.php
+++ b/tests/test_report_reminders.php
@@ -4,7 +4,7 @@
  * (grace_addon/files/general/www/public/report_reminders_lib.php).
  *
  * The date is injected, so every scenario below is deterministic. Each case
- * prints a one-line story of what it proves — handy for demos.
+ * prints a one-line story of what it proves, handy for demos.
  */
 
 define('GRACE_TEST_MODE', true);
@@ -20,7 +20,7 @@ function check($story, $actual, $expected)
     if ($actual === $expected) {
         echo "[PASS] $story\n";
     } else {
-        echo "[FAIL] $story — expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n";
+        echo "[FAIL] $story, expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n";
         $failures++;
     }
 }
@@ -32,7 +32,7 @@ function summarise($due)
 }
 
 // ---------------------------------------------------------------------------
-// Scenario A: a brand-new install — empty database, no company yet
+// Scenario A: a brand-new install, empty database, no company yet
 // ---------------------------------------------------------------------------
 $tmpA = tempnam(sys_get_temp_dir(), 'grace_rem_a_') . '.db';
 $pdoA = initializeDatabase($tmpA);
@@ -68,7 +68,7 @@ check('Day 3 of July: June shipped nothing -> no reminder', summarise(getDueRepo
 actionReportReminder($pdoB, 'monthly', '2026-05', 'dismissed');
 check('After dismissing May: day 3 of June is silent', summarise(getDueReportReminders($pdoB, '2026-06-03')), '');
 
-// January: annual + monthly (December shipped) can both be due — the maximum
+// January: annual + monthly (December shipped) can both be due, the maximum
 check('3 January: December report AND annual stocktake both due (the max of two)', summarise(getDueReportReminders($pdoB, '2027-01-03')), 'monthly:2026-12 annual:2026');
 check('20 January: monthly window closed, annual still due all month', summarise(getDueReportReminders($pdoB, '2027-01-20')), 'annual:2026');
 
@@ -80,7 +80,7 @@ check('After drafting the annual email: January is silent', summarise(getDueRepo
 check('Next June (May 2027 shipped nothing): silent', summarise(getDueReportReminders($pdoB, '2027-06-03')), '');
 
 // ---------------------------------------------------------------------------
-// Scenario C: company exists but the ledger only starts THIS year —
+// Scenario C: company exists but the ledger only starts THIS year
 // no annual reminder for a year GRACe wasn't tracking
 // ---------------------------------------------------------------------------
 $tmpC = tempnam(sys_get_temp_dir(), 'grace_rem_c_') . '.db';


### PR DESCRIPTION
## Changes

Three UI/copy tidy-ups for 0.17.2:

1. **Removed the "Recalls" section** from Plant Tracking. It only held the disabled "Initiate Recall — coming soon" placeholder, so the page now ends after Shipping.
2. **Reordered the Administration page.** Record Management is now the first section, with its cards in this order: Chain of Custody Documents, Company Licenses, Manage SOPs, Police Vet Check Records, Offtake Agreements. Contact Management, Genetics Management, and System Management follow.
3. **Removed every em-dash.** All em-dashes across user-facing copy, code comments, and the docs (README, DEVELOPMENT.md, DOCS.md, CHANGELOG) have been rephrased so they no longer need one. Confirmed zero remain repo-wide (excluding the vendored TCPDF library).

## Verification

- Confirmed via DOM inspection in the preview: Plant Tracking now shows only "Plant / Product Management" and "Shipping"; Administration's first section is Record Management with the exact card order above.
- Full CI suite passes (versions consistent at 0.17.2).

Version bumped to 0.17.2 in config.yaml, nav.php, header.php, and the changelog (added a one-line note under Fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
